### PR TITLE
Refactor disconnect listening

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stage("Deploy: Frontend") {
       when {
         expression {
-           env.BRANCH_NAME == "main"
+           env.BRANCH_NAME == "testingFix"
         }
       }
       steps {
@@ -36,7 +36,7 @@ pipeline {
     stage("Deploy: Backend") {
       when {
         expression {
-           env.BRANCH_NAME == "main"
+           env.BRANCH_NAME == "testingFix"
         }
       }
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stage("Deploy: Frontend") {
       when {
         expression {
-           env.BRANCH_NAME == "testingFix"
+           env.BRANCH_NAME == "main"
         }
       }
       steps {
@@ -36,7 +36,7 @@ pipeline {
     stage("Deploy: Backend") {
       when {
         expression {
-           env.BRANCH_NAME == "testingFix"
+           env.BRANCH_NAME == "main"
         }
       }
       steps {

--- a/backend/src/main/java/com/leancoffree/backend/config/WebSocketDisconnectListener.java
+++ b/backend/src/main/java/com/leancoffree/backend/config/WebSocketDisconnectListener.java
@@ -1,0 +1,38 @@
+package com.leancoffree.backend.config;
+
+import static com.leancoffree.backend.enums.RefreshUsersCommand.DROP;
+
+import com.leancoffree.backend.controller.RefreshUsersInSessionException;
+import com.leancoffree.backend.domain.model.RefreshUsersRequest;
+import com.leancoffree.backend.service.DropUserInSessionService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Slf4j
+@Component
+public class WebSocketDisconnectListener {
+
+  private final DropUserInSessionService dropUserInSessionService;
+
+  public WebSocketDisconnectListener(final DropUserInSessionService dropUserInSessionService) {
+    this.dropUserInSessionService = dropUserInSessionService;
+  }
+
+  @EventListener
+  public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+    final StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+    final StompPrincipal userIdObject = (StompPrincipal) headerAccessor.getHeader("simpUser");
+    try {
+      dropUserInSessionService.dropUserInSessionAndReturnAllUsers(RefreshUsersRequest.builder()
+          .command(DROP)
+          .sessionId(headerAccessor.getSessionId())
+          .websocketUserId(userIdObject.getName())
+          .build());
+    } catch (final RefreshUsersInSessionException e) {
+      log.error("Caught RefreshUsersInSessionException in disconnect listener: ", e);
+    }
+  }
+}

--- a/backend/src/main/java/com/leancoffree/backend/controller/RefreshUsersController.java
+++ b/backend/src/main/java/com/leancoffree/backend/controller/RefreshUsersController.java
@@ -23,17 +23,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 public class RefreshUsersController {
 
   private final RefreshUsersInSessionService refreshUsersInSessionService;
-  private final SimpMessagingTemplate webSocketMessagingTemplate;
 
-  public RefreshUsersController(final RefreshUsersInSessionService refreshUsersInSessionService,
-      final SimpMessagingTemplate webSocketMessagingTemplate) {
+  public RefreshUsersController(final RefreshUsersInSessionService refreshUsersInSessionService) {
     this.refreshUsersInSessionService = refreshUsersInSessionService;
-    this.webSocketMessagingTemplate = webSocketMessagingTemplate;
   }
 
   @CrossOrigin
   @PostMapping("/refresh-users")
-  public ResponseEntity<Object> addUserHttpEndpoint(
+  public ResponseEntity<Object> refreshUsersEndpoint(
       @Valid @RequestBody final RefreshUsersRequest refreshUsersRequest, final Errors errors) {
 
     if (errors.hasErrors()) {
@@ -41,12 +38,7 @@ public class RefreshUsersController {
     }
 
     try {
-      final String websocketMessageString = refreshUsersInSessionService
-          .refreshUsersInSession(refreshUsersRequest);
-
-      webSocketMessagingTemplate
-          .convertAndSend("/topic/session/" + refreshUsersRequest.getSessionId(),
-              websocketMessageString);
+      refreshUsersInSessionService.refreshUsersInSession(refreshUsersRequest);
 
       return ResponseEntity.ok(SuccessOrFailureAndErrorBody.builder()
           .status(SUCCESS)

--- a/backend/src/main/java/com/leancoffree/backend/repository/UsersRepository.java
+++ b/backend/src/main/java/com/leancoffree/backend/repository/UsersRepository.java
@@ -9,6 +9,5 @@ import org.springframework.data.repository.CrudRepository;
 public interface UsersRepository extends CrudRepository<UsersEntity, UsersId> {
 
   Optional<List<UsersEntity>> findAllBySessionId(final String sessionId);
-
-  void deleteByWebsocketUserId(final String websocketUserId);
+  Optional<UsersEntity> findByWebsocketUserId(final String websocketUserId);
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionService.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionService.java
@@ -5,6 +5,6 @@ import com.leancoffree.backend.domain.model.RefreshUsersRequest;
 
 public interface AddUserToSessionService {
 
-  String addUserToSessionAndReturnAllUsers(final RefreshUsersRequest refreshUsersRequest)
+  void addUserToSessionAndReturnAllUsers(final RefreshUsersRequest refreshUsersRequest)
       throws RefreshUsersInSessionException;
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/DropUserInSessionService.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/DropUserInSessionService.java
@@ -5,6 +5,6 @@ import com.leancoffree.backend.domain.model.RefreshUsersRequest;
 
 public interface DropUserInSessionService {
 
-  String dropUserInSessionAndReturnAllUsers(final RefreshUsersRequest refreshUsersRequest)
+  void dropUserInSessionAndReturnAllUsers(final RefreshUsersRequest refreshUsersRequest)
       throws RefreshUsersInSessionException;
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshUsersInSessionService.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshUsersInSessionService.java
@@ -5,6 +5,6 @@ import com.leancoffree.backend.domain.model.RefreshUsersRequest;
 
 public interface RefreshUsersInSessionService {
 
-  String refreshUsersInSession(final RefreshUsersRequest refreshUsersRequest)
+  void refreshUsersInSession(final RefreshUsersRequest refreshUsersRequest)
       throws RefreshUsersInSessionException;
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshUsersInSessionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshUsersInSessionServiceImpl.java
@@ -1,6 +1,7 @@
 package com.leancoffree.backend.service;
 
 import static com.leancoffree.backend.enums.RefreshUsersCommand.ADD;
+import static com.leancoffree.backend.enums.RefreshUsersCommand.DROP;
 
 import com.leancoffree.backend.controller.RefreshUsersInSessionException;
 import com.leancoffree.backend.domain.model.RefreshUsersRequest;
@@ -18,10 +19,12 @@ public class RefreshUsersInSessionServiceImpl implements RefreshUsersInSessionSe
     this.dropUserInSessionService = dropUserInSessionService;
   }
 
-  public String refreshUsersInSession(final RefreshUsersRequest refreshUsersRequest)
+  public void refreshUsersInSession(final RefreshUsersRequest refreshUsersRequest)
       throws RefreshUsersInSessionException {
-    return ADD.equals(refreshUsersRequest.getCommand())
-        ? addUserToSessionService.addUserToSessionAndReturnAllUsers(refreshUsersRequest)
-        : dropUserInSessionService.dropUserInSessionAndReturnAllUsers(refreshUsersRequest);
+    if (ADD.equals(refreshUsersRequest.getCommand())) {
+      addUserToSessionService.addUserToSessionAndReturnAllUsers(refreshUsersRequest);
+    } else if (DROP.equals(refreshUsersRequest.getCommand())) {
+      dropUserInSessionService.dropUserInSessionAndReturnAllUsers(refreshUsersRequest);
+    }
   }
 }

--- a/frontend/src/session/Session.js
+++ b/frontend/src/session/Session.js
@@ -19,29 +19,13 @@ class Session extends React.Component {
     this.submitDisplayName = this.submitDisplayName.bind(this);   
     this.onUpdateUsers = this.onUpdateUsers.bind(this);
     this.onConnected = this.onConnected.bind(this);
-    this.sendDisconnectRequest = this.sendDisconnectRequest.bind(this);
   }
 
   invalidSessionProvided() {
     window.location = process.env.REACT_APP_FRONTEND_BASEURL;
   }
 
-  sendDisconnectRequest() {
-    console.log("SessionId: " + this.state.sessionId);
-    console.log("websocketUserId: " + this.state.websocketUserId);
-    let self = this;
-    Axios.post(process.env.REACT_APP_BACKEND_BASEURL + "/refresh-users", {displayName: self.state.userDisplayName, sessionId: self.state.sessionId, command: "DROP", websocketUserId: self.state.websocketUserId})
-    .catch(function (error) {
-      console.log("Error while adding displayname to backend: " + error + " - " + JSON.stringify(error.response.data))
-    });
-  }
-
   componentDidMount() {
-    window.addEventListener("beforeunload", (eventListener) => {  
-      eventListener.preventDefault();
-      this.sendDisconnectRequest();
-    });
-
     let windowHref = window.location.href;
     let url = windowHref.match(process.env.REACT_APP_SESSION_REGEX);
     if(url === null) {

--- a/frontend/src/session/Session.js
+++ b/frontend/src/session/Session.js
@@ -27,6 +27,8 @@ class Session extends React.Component {
   }
 
   sendDisconnectRequest() {
+    console.log("SessionId: " + this.state.sessionId);
+    console.log("websocketUserId: " + this.state.websocketUserId);
     let self = this;
     Axios.post(process.env.REACT_APP_BACKEND_BASEURL + "/refresh-users", {displayName: self.state.userDisplayName, sessionId: self.state.sessionId, command: "DROP", websocketUserId: self.state.websocketUserId})
     .catch(function (error) {
@@ -36,6 +38,7 @@ class Session extends React.Component {
 
   componentDidMount() {
     window.addEventListener("beforeunload", (eventListener) => {  
+      eventListener.preventDefault();
       this.sendDisconnectRequest();
     });
 


### PR DESCRIPTION
* Add eventlistener on server that listens for disconnect events, it will call the dropuser service which drops the user from the session in the db and broadcasts the updated list of users if any
* remove client code for calling refresh users endpoint on window close
* refactor refresh-users flow in back end to support entering flow from controller or service level to support adding from HTTP endpoint as well as dropping from disconnect listener