### PR TITLE
Add transition to discussion logic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stage("Deploy: Frontend") {
       when {
         expression {
-           env.BRANCH_NAME == "moveToDiscussionStep"
+           env.BRANCH_NAME == "main"
         }
       }
       steps {
@@ -36,7 +36,7 @@ pipeline {
     stage("Deploy: Backend") {
       when {
         expression {
-           env.BRANCH_NAME == "moveToDiscussionStep"
+           env.BRANCH_NAME == "main"
         }
       }
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stage("Deploy: Frontend") {
       when {
         expression {
-           env.BRANCH_NAME == "main"
+           env.BRANCH_NAME == "moveToDiscussionStep"
         }
       }
       steps {
@@ -36,7 +36,7 @@ pipeline {
     stage("Deploy: Backend") {
       when {
         expression {
-           env.BRANCH_NAME == "main"
+           env.BRANCH_NAME == "moveToDiscussionStep"
         }
       }
       steps {

--- a/backend/src/main/java/com/leancoffree/backend/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/leancoffree/backend/config/WebSocketConfig.java
@@ -12,7 +12,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void configureMessageBroker(final MessageBrokerRegistry config) {
-    config.enableSimpleBroker("/topic/users/session", "/topic/discussion-topics/session");
+    config.enableSimpleBroker("/topic/users/session", "/topic/discussion-topics/session",
+        "/topic/status/session");
     config.setApplicationDestinationPrefixes("/ws");
   }
 

--- a/backend/src/main/java/com/leancoffree/backend/controller/PostVoteController.java
+++ b/backend/src/main/java/com/leancoffree/backend/controller/PostVoteController.java
@@ -42,9 +42,7 @@ public class PostVoteController {
     for (final ObjectError error : errors.getAllErrors()) {
       errorsList.add(error.getDefaultMessage());
     }
-    return ResponseEntity.ok(SuccessOrFailureAndErrorBody.builder()
-        .status(FAILURE)
-        .error(String.join(", ", errorsList))
-        .build());
+    return ResponseEntity
+        .ok(new SuccessOrFailureAndErrorBody(FAILURE, String.join(", ", errorsList)));
   }
 }

--- a/backend/src/main/java/com/leancoffree/backend/controller/RefreshUsersController.java
+++ b/backend/src/main/java/com/leancoffree/backend/controller/RefreshUsersController.java
@@ -3,7 +3,7 @@ package com.leancoffree.backend.controller;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 
 import com.leancoffree.backend.domain.model.RefreshUsersRequest;
-import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.domain.model.SessionStatusResponse;
 import com.leancoffree.backend.service.RefreshUsersService;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +27,7 @@ public class RefreshUsersController {
 
   @CrossOrigin
   @PostMapping("/refresh-users")
-  public ResponseEntity<SuccessOrFailureAndErrorBody> refreshUsersEndpoint(
+  public ResponseEntity<SessionStatusResponse> refreshUsersEndpoint(
       @Valid @RequestBody final RefreshUsersRequest refreshUsersRequest, final Errors errors) {
 
     if (errors.hasErrors()) {
@@ -36,13 +36,13 @@ public class RefreshUsersController {
     return ResponseEntity.ok(refreshUsersService.refreshUsers(refreshUsersRequest));
   }
 
-  private ResponseEntity<SuccessOrFailureAndErrorBody> buildValidationErrorsResponse(
+  private ResponseEntity<SessionStatusResponse> buildValidationErrorsResponse(
       final Errors errors) {
     final List<String> errorsList = new ArrayList<>();
     for (final ObjectError error : errors.getAllErrors()) {
       errorsList.add(error.getDefaultMessage());
     }
-    return ResponseEntity.ok(SuccessOrFailureAndErrorBody.builder()
+    return ResponseEntity.ok(SessionStatusResponse.builder()
         .status(FAILURE)
         .error(String.join(", ", errorsList))
         .build());

--- a/backend/src/main/java/com/leancoffree/backend/controller/SubmitTopicController.java
+++ b/backend/src/main/java/com/leancoffree/backend/controller/SubmitTopicController.java
@@ -42,9 +42,7 @@ public class SubmitTopicController {
     for (final ObjectError error : errors.getAllErrors()) {
       errorsList.add(error.getDefaultMessage());
     }
-    return ResponseEntity.ok(SuccessOrFailureAndErrorBody.builder()
-        .status(FAILURE)
-        .error(String.join(", ", errorsList))
-        .build());
+    return ResponseEntity
+        .ok(new SuccessOrFailureAndErrorBody(FAILURE, String.join(", ", errorsList)));
   }
 }

--- a/backend/src/main/java/com/leancoffree/backend/controller/TransitionToDiscussionController.java
+++ b/backend/src/main/java/com/leancoffree/backend/controller/TransitionToDiscussionController.java
@@ -1,0 +1,27 @@
+package com.leancoffree.backend.controller;
+
+import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.service.TransitionToDiscussionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TransitionToDiscussionController {
+
+  private final TransitionToDiscussionService transitionToDiscussionService;
+
+  public TransitionToDiscussionController(
+      final TransitionToDiscussionService transitionToDiscussionService) {
+    this.transitionToDiscussionService = transitionToDiscussionService;
+  }
+
+  @CrossOrigin
+  @PostMapping("/transition-to-discussion/{sessionId}")
+  public ResponseEntity<SuccessOrFailureAndErrorBody> transitionToDiscussionEndpoint(
+      @PathVariable("sessionId") final String sessionId) {
+    return ResponseEntity.ok(transitionToDiscussionService.transitionToDiscussion(sessionId));
+  }
+}

--- a/backend/src/main/java/com/leancoffree/backend/domain/model/SessionStatusResponse.java
+++ b/backend/src/main/java/com/leancoffree/backend/domain/model/SessionStatusResponse.java
@@ -1,0 +1,22 @@
+package com.leancoffree.backend.domain.model;
+
+import com.leancoffree.backend.enums.SessionStatus;
+import com.leancoffree.backend.enums.SuccessOrFailure;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SessionStatusResponse extends SuccessOrFailureAndErrorBody {
+
+  private SessionStatus sessionStatus;
+
+  @Builder
+  public SessionStatusResponse(final SessionStatus sessionStatus, final SuccessOrFailure status, final String error) {
+    super(status, error);
+    this.sessionStatus = sessionStatus;
+  }
+}

--- a/backend/src/main/java/com/leancoffree/backend/domain/model/SuccessOrFailureAndErrorBody.java
+++ b/backend/src/main/java/com/leancoffree/backend/domain/model/SuccessOrFailureAndErrorBody.java
@@ -2,12 +2,10 @@ package com.leancoffree.backend.domain.model;
 
 import com.leancoffree.backend.enums.SuccessOrFailure;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class SuccessOrFailureAndErrorBody {

--- a/backend/src/main/java/com/leancoffree/backend/enums/SessionStatus.java
+++ b/backend/src/main/java/com/leancoffree/backend/enums/SessionStatus.java
@@ -2,5 +2,6 @@ package com.leancoffree.backend.enums;
 
 public enum SessionStatus {
   WAITING_TO_START,
-  STARTED
+  STARTED,
+  DISCUSSING
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionService.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionService.java
@@ -1,10 +1,10 @@
 package com.leancoffree.backend.service;
 
 import com.leancoffree.backend.domain.model.RefreshUsersRequest;
-import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.domain.model.SessionStatusResponse;
 
 public interface AddUserToSessionService {
 
-  SuccessOrFailureAndErrorBody addUserToSessionAndReturnAllUsers(
+  SessionStatusResponse addUserToSessionAndReturnAllUsers(
       final RefreshUsersRequest refreshUsersRequest);
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/DropUserInSessionService.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/DropUserInSessionService.java
@@ -1,10 +1,10 @@
 package com.leancoffree.backend.service;
 
 import com.leancoffree.backend.domain.model.RefreshUsersRequest;
-import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.domain.model.SessionStatusResponse;
 
 public interface DropUserInSessionService {
 
-  SuccessOrFailureAndErrorBody dropUserInSessionAndReturnAllUsers(
+  SessionStatusResponse dropUserInSessionAndReturnAllUsers(
       final RefreshUsersRequest refreshUsersRequest);
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshUsersService.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshUsersService.java
@@ -1,9 +1,9 @@
 package com.leancoffree.backend.service;
 
 import com.leancoffree.backend.domain.model.RefreshUsersRequest;
-import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.domain.model.SessionStatusResponse;
 
 public interface RefreshUsersService {
 
-  SuccessOrFailureAndErrorBody refreshUsers(final RefreshUsersRequest refreshUsersRequest);
+  SessionStatusResponse refreshUsers(final RefreshUsersRequest refreshUsersRequest);
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshUsersServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshUsersServiceImpl.java
@@ -3,7 +3,7 @@ package com.leancoffree.backend.service;
 import static com.leancoffree.backend.enums.RefreshUsersCommand.ADD;
 
 import com.leancoffree.backend.domain.model.RefreshUsersRequest;
-import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.domain.model.SessionStatusResponse;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,7 +18,7 @@ public class RefreshUsersServiceImpl implements RefreshUsersService {
     this.dropUserInSessionService = dropUserInSessionService;
   }
 
-  public SuccessOrFailureAndErrorBody refreshUsers(final RefreshUsersRequest refreshUsersRequest) {
+  public SessionStatusResponse refreshUsers(final RefreshUsersRequest refreshUsersRequest) {
     if (ADD.equals(refreshUsersRequest.getCommand())) {
       return addUserToSessionService.addUserToSessionAndReturnAllUsers(refreshUsersRequest);
     } else {

--- a/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionService.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionService.java
@@ -1,0 +1,8 @@
+package com.leancoffree.backend.service;
+
+import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+
+public interface TransitionToDiscussionService {
+
+  SuccessOrFailureAndErrorBody transitionToDiscussion(final String sessionId);
+}

--- a/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
@@ -1,0 +1,33 @@
+package com.leancoffree.backend.service;
+
+import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
+import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
+
+import com.leancoffree.backend.domain.entity.SessionsEntity;
+import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.enums.SessionStatus;
+import com.leancoffree.backend.repository.SessionsRepository;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TransitionToDiscussionServiceImpl implements TransitionToDiscussionService {
+
+  private final SessionsRepository sessionsRepository;
+
+  public TransitionToDiscussionServiceImpl(final SessionsRepository sessionsRepository) {
+    this.sessionsRepository = sessionsRepository;
+  }
+
+  public SuccessOrFailureAndErrorBody transitionToDiscussion(final String sessionId) {
+    final Optional<SessionsEntity> sessionsEntityOptional = sessionsRepository.findById(sessionId);
+    if(sessionsEntityOptional.isEmpty()) {
+      return new SuccessOrFailureAndErrorBody(FAILURE, "Couldn't find session with that ID");
+    }
+
+    final SessionsEntity sessionsEntity = sessionsEntityOptional.get();
+    sessionsEntity.setSessionStatus(SessionStatus.DISCUSSING);
+    sessionsRepository.save(sessionsEntity);
+    return new SuccessOrFailureAndErrorBody(SUCCESS, null);
+  }
+}

--- a/backend/src/main/java/com/leancoffree/backend/service/VerifySessionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/VerifySessionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.leancoffree.backend.service;
 
+import static com.leancoffree.backend.enums.SessionStatus.DISCUSSING;
 import static com.leancoffree.backend.enums.SessionStatus.STARTED;
 import static com.leancoffree.backend.enums.SessionVerificationStatus.VERIFICATION_FAILURE;
 import static com.leancoffree.backend.enums.SessionVerificationStatus.VERIFICATION_SUCCESS;
@@ -24,13 +25,13 @@ public class VerifySessionServiceImpl implements VerifySessionService {
     final Optional<SessionsEntity> sessionsEntityOptional = sessionsRepository.findById(sessionId);
 
     VerifySessionResponse verifySessionResponse;
-    if (sessionsEntityOptional.isPresent() && sessionsEntityOptional.get().getSessionStatus()
-        .equals(STARTED)) {
+    if (sessionsEntityOptional.isPresent() && (sessionsEntityOptional.get().getSessionStatus()
+        .equals(STARTED) || sessionsEntityOptional.get().getSessionStatus().equals(DISCUSSING))) {
       verifySessionResponse = VerifySessionResponse.builder()
           .verificationStatus(VERIFICATION_SUCCESS)
           .sessionDetails(SessionDetails.builder()
               .sessionId(sessionId)
-              .sessionStatus(STARTED)
+              .sessionStatus(sessionsEntityOptional.get().getSessionStatus())
               .build())
           .build();
     } else {

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+class DiscussionPage extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      topics: props.topics,
+      userDisplayName: props.userInfo.displayName,
+    }
+  }
+
+
+  render() {
+    return (
+      <div>
+        Discussion Page
+      </div>
+    )
+  }
+}
+
+export default DiscussionPage;

--- a/frontend/src/session/Session.js
+++ b/frontend/src/session/Session.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Axios from 'axios';
+import DiscussionPage from './DiscussionPage';
 import './session.css'
 
 let stompClient = null;
@@ -217,8 +218,17 @@ class Session extends React.Component {
           <div class="session-grid-item usersSection">
             <div>All here:</div>
             <div>{this.getAllHere()}</div>
+            <div class="nextSectionButton">
+              <button onClick={() => this.setState({sessionStatus: "DISCUSSING"})}>End voting and go to next section</button>
+            </div>
           </div>
         </div>
+      )
+    }
+
+    else if (this.state.sessionStatus === "DISCUSSING") {
+      return (
+        <DiscussionPage topics={this.state.topics} userInfo={{displayName: this.state.userDisplayName}} />
       )
     }
 

--- a/frontend/src/session/Session.js
+++ b/frontend/src/session/Session.js
@@ -40,7 +40,7 @@ class Session extends React.Component {
     var self = this;  
     Axios.post(process.env.REACT_APP_BACKEND_BASEURL + '/verify-session/' + sessionIdFromAddress, null)
       .then((response) => {
-        if(self.isVerificationResponseValid(response, sessionIdFromAddress[0]) && response.data.sessionDetails.sessionStatus === "STARTED" || response.data.sessionDetails.sessionStatus === "DISCUSSING") {
+        if(self.isVerificationResponseValid(response, sessionIdFromAddress[0]) && (response.data.sessionDetails.sessionStatus === "STARTED" || response.data.sessionDetails.sessionStatus === "DISCUSSING")) {
           self.connectToWebSocketServer();
           self.setState({
             isSessionVerified: true,

--- a/frontend/src/session/session.css
+++ b/frontend/src/session/session.css
@@ -82,3 +82,9 @@
   height: 85%;
   border-bottom: solid black 1px;
 }
+
+.nextSectionButton {
+  position: absolute;
+  width: 13vw;
+  bottom: 1vw;
+}


### PR DESCRIPTION
* add frontend code for button to transition to next step, flows like so:
1. add `/transition-to-discussion/{sessionId}` endpoint which will update session status in DB and broadcast the change to any listening clients
2. add frontend subscription to listen for broadcast status changes
3. add logic for returning the correct status on verification instead of always STARTED, verification now succeeds if STARTED or DISCUSSING
4. After verifying and providing display name, refresh users now returns the session status so after name is submitted, frontend can go to correct session. Had to extend SuccessOrFailureAndErrorBody in new SessionStatusResponse to include the Session status

* this covers transition all three user types: the user that presses next section button, other users in the session, new users joining the session