### PR TITLE
Add starter frontend discussion section

### DIFF
--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -19,11 +19,11 @@ class DiscussionPage extends React.Component {
       let bLength = b.voters.length;
       return bLength - aLength;
     });
-    for(let i = 0; i < allTopics.length; i++) {
+    for(let i = 1; i <= allTopics.length - 1; i++) {
       let text = allTopics[i].text;
       let votes = allTopics[i].voters.length;
       topicsElements.push(
-        <div key={i.toString()} class="cardItem" style={{gridRow: i+1, gridColumn: 1}}>
+        <div key={i.toString()} class="cardItem" style={{gridRow: i, gridColumn: 1, marginLeft: '2.5vw', marginRight: '2.5vw'}}>
           <p class="topicsText">{text}</p>
           <p class="votesText">Votes: {votes}</p>
         </div>
@@ -39,7 +39,8 @@ class DiscussionPage extends React.Component {
           {this.getAllTopicCards()}
         </div>
           <div class="currentDiscussionItem">
-            {this.state.topics[0].text}
+            <h5 style={{textAlign: "center"}}>Current discussion item</h5>
+            <h2 style={{textAlign: "center"}}>{this.state.topics[0].text}</h2>
           </div>
 
           <div class="session-grid-item usersSection column3">

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -14,11 +14,16 @@ class DiscussionPage extends React.Component {
     let topicsElements = [];
 
     let allTopics = this.state.topics;
+    allTopics.sort((a,b) => {
+      let aLength = a.voters.length;
+      let bLength = b.voters.length;
+      return bLength - aLength;
+    });
     for(let i = 0; i < allTopics.length; i++) {
       let text = allTopics[i].text;
       let votes = allTopics[i].voters.length;
       topicsElements.push(
-        <div class="cardItem" style={{gridRow: i, gridColumn: 1}}>
+        <div key={i.toString()} class="cardItem" style={{gridRow: i+1, gridColumn: 1}}>
           <p class="topicsText">{text}</p>
           <p class="votesText">Votes: {votes}</p>
         </div>

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -10,11 +10,37 @@ class DiscussionPage extends React.Component {
     }
   }
 
+  getAllTopicCards() {
+    let topicsElements = [];
+
+    let allTopics = this.state.topics;
+    for(let i = 0; i < allTopics.length; i++) {
+      let text = allTopics[i].text;
+      let votes = allTopics[i].voters.length;
+      topicsElements.push(
+        <div class="cardItem" style={{gridRow: i, gridColumn: 1}}>
+          <p class="topicsText">{text}</p>
+          <p class="votesText">Votes: {votes}</p>
+        </div>
+      );
+    }
+    return topicsElements;
+  }
 
   render() {
     return (
-      <div>
-        Discussion Page
+      <div class="session-grid-container">
+        <div class="discussCards-grid-container">
+          {this.getAllTopicCards()}
+        </div>
+          <div class="currentDiscussionItem">
+            {this.state.topics[0].text}
+          </div>
+
+          <div class="session-grid-item usersSection column3">
+            <div>All here:</div>
+            <div>{this.props.getAllHere()}</div>
+          </div>
       </div>
     )
   }

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -23,7 +23,7 @@ class DiscussionPage extends React.Component {
       let text = allTopics[i].text;
       let votes = allTopics[i].voters.length;
       topicsElements.push(
-        <div key={i.toString()} class="cardItem" style={{gridRow: i, gridColumn: 1, marginLeft: '2.5vw', marginRight: '2.5vw'}}>
+        <div key={i.toString()} class="cardItem discussionCardItem" style={{gridRow: i}}>
           <p class="topicsText">{text}</p>
           <p class="votesText">Votes: {votes}</p>
         </div>
@@ -39,8 +39,8 @@ class DiscussionPage extends React.Component {
           {this.getAllTopicCards()}
         </div>
           <div class="currentDiscussionItem">
-            <h5 style={{textAlign: "center"}}>Current discussion item</h5>
-            <h2 style={{textAlign: "center"}}>{this.state.topics[0].text}</h2>
+            <h5 class="currentTopicHeader">Current discussion item</h5>
+            <h2 class="currentTopicHeader">{this.state.topics[0].text}</h2>
           </div>
 
           <div class="session-grid-item usersSection column3">

--- a/frontend/src/session/Session.js
+++ b/frontend/src/session/Session.js
@@ -23,6 +23,7 @@ class Session extends React.Component {
     this.submitDisplayName = this.submitDisplayName.bind(this);
     this.submitCard = this.submitCard.bind(this);
     this.transitionToDiscussion = this.transitionToDiscussion.bind(this);
+    this.getAllHere = this.getAllHere.bind(this);
   }
 
   componentDidMount() {
@@ -245,15 +246,7 @@ class Session extends React.Component {
 
     else if (this.state.sessionStatus === "DISCUSSING") {
       return (
-        <div class="session-grid-container">
-          <div class="session-grid-item cardsSection">
-              <DiscussionPage topics={this.state.topics} userInfo={{displayName: this.state.userDisplayName}} />
-          </div>
-          <div class="session-grid-item usersSection">
-            <div>All here:</div>
-            <div>{this.getAllHere()}</div>
-          </div>
-        </div>
+        <DiscussionPage getAllHere={this.getAllHere} topics={this.state.topics} userInfo={{displayName: this.state.userDisplayName}} />
       )
     }
 

--- a/frontend/src/session/Session.js
+++ b/frontend/src/session/Session.js
@@ -112,9 +112,9 @@ class Session extends React.Component {
     for(let i = 0; i < this.state.usersInAttendance.length; i++) {
       let username = this.state.usersInAttendance[i];
       if(username === this.state.userDisplayName) {
-        allHereListItems.push(<li class="usernameList"><b>{this.state.usersInAttendance[i]}</b></li>);
+        allHereListItems.push(<li key={i.toString()} class="usernameList"><b>{this.state.usersInAttendance[i]}</b></li>);
       } else {
-        allHereListItems.push(<li class="usernameList">{this.state.usersInAttendance[i]}</li>);
+        allHereListItems.push(<li key={i.toString()} class="usernameList">{this.state.usersInAttendance[i]}</li>);
       }
     }
     return (
@@ -162,7 +162,7 @@ class Session extends React.Component {
       // divide by 5 to get row number, count is 1 based so add 1 to result
       let rowNum = Math.floor((i + 1) / 5) + 1;
       topicsElements.push(
-        <div class="cardItem" style={{gridColumn: columnNum, gridRow: rowNum}}>
+        <div key={i.toString()} class="cardItem" style={{gridColumn: columnNum, gridRow: rowNum}}>
           <p id="topicText">{text}</p>
           <p id="votesText">Votes: {votes}</p>
           {votingButton}

--- a/frontend/src/session/session.css
+++ b/frontend/src/session/session.css
@@ -26,7 +26,6 @@
   grid-column: 1;
   grid-row: 1;
   width: 85vw;
-  min-width: 85vw;
 }
 
 .usersSection {

--- a/frontend/src/session/session.css
+++ b/frontend/src/session/session.css
@@ -8,19 +8,33 @@
 .session-grid-container {
   display: grid;
   min-height: 100vh;
+  max-width: 100vw;
+}
+
+.discussCards-grid-container {
+  display: grid;
+  width: 20vw;
+  min-height: 100vh;
+  max-height: 100vh;
+  border-right: solid black 1px;
+  overflow: scroll;
+  grid-row: 1;
+  grid-column: 1;
 }
 
 .cardsSection {
   grid-column: 1;
   grid-row: 1;
   width: 85vw;
+  min-width: 85vw;
 }
 
 .usersSection {
   padding-left: 1vw;
   grid-column: 2;
   grid-row: 1;
-  width: 15vw;
+  min-width: 15vw;
+  max-width: 15vw;
   border-left: 1px solid black;
 }
 
@@ -77,7 +91,6 @@
 
 #topicText {
   overflow: scroll;
-
   width: 100%;
   height: 85%;
   border-bottom: solid black 1px;
@@ -87,4 +100,14 @@
   position: absolute;
   width: 13vw;
   bottom: 1vw;
+}
+
+.currentDiscussionItem {
+  grid-row: 1;
+  grid-column: 2;
+  width: 65vw;
+}
+
+.column3 {
+  grid-column: 3;
 }

--- a/frontend/src/session/session.css
+++ b/frontend/src/session/session.css
@@ -110,3 +110,13 @@
 .column3 {
   grid-column: 3;
 }
+
+.discussionCardItem {
+  grid-column: 1;
+  margin-left: 2.5vw;
+  margin-right: 2.5vw;
+}
+
+.currentTopicHeader{
+  text-align: center;
+}


### PR DESCRIPTION
* add basic discussion page which nicely shows all discussion cards in right column, the current discussion item in large heading in the center, and active users on the right
* discussion cards are sorted by most votes
* this PR sets up the space for implementing next steps: a timer for current discussion item, space to show past discussion items, code structure for querying for interest time extension