### PR TITLE
Add discussion timer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stage("Deploy: Frontend") {
       when {
         expression {
-           env.BRANCH_NAME == "main"
+           env.BRANCH_NAME == "addDiscussionTimer"
         }
       }
       steps {
@@ -36,7 +36,7 @@ pipeline {
     stage("Deploy: Backend") {
       when {
         expression {
-           env.BRANCH_NAME == "main"
+           env.BRANCH_NAME == "addDiscussionTimer"
         }
       }
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stage("Deploy: Frontend") {
       when {
         expression {
-           env.BRANCH_NAME == "addDiscussionTimer"
+           env.BRANCH_NAME == "main"
         }
       }
       steps {
@@ -36,7 +36,7 @@ pipeline {
     stage("Deploy: Backend") {
       when {
         expression {
-           env.BRANCH_NAME == "addDiscussionTimer"
+           env.BRANCH_NAME == "main"
         }
       }
       steps {

--- a/backend/src/main/java/com/leancoffree/backend/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/leancoffree/backend/config/WebSocketConfig.java
@@ -12,8 +12,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void configureMessageBroker(final MessageBrokerRegistry config) {
-    config.enableSimpleBroker("/topic/users/session", "/topic/discussion-topics/session",
-        "/topic/status/session");
+    config.enableSimpleBroker("/topic/users/session", "/topic/discussion-topics/session");
     config.setApplicationDestinationPrefixes("/ws");
   }
 

--- a/backend/src/main/java/com/leancoffree/backend/domain/entity/SessionsEntity.java
+++ b/backend/src/main/java/com/leancoffree/backend/domain/entity/SessionsEntity.java
@@ -39,4 +39,7 @@ public class SessionsEntity {
   @UpdateTimestamp
   @Column(name = "updated_timestamp")
   private Instant updatedTimestamp;
+
+  @Column(name = "current_topic_end_time")
+  private Instant currentTopicEndTime;
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsServiceImpl.java
@@ -1,13 +1,17 @@
 package com.leancoffree.backend.service;
 
+import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
 
+import com.leancoffree.backend.domain.entity.SessionsEntity;
 import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.repository.SessionsRepository;
 import com.leancoffree.backend.repository.TopicsRepository;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -19,11 +23,14 @@ public class BroadcastTopicsServiceImpl implements BroadcastTopicsService {
   private static final String websocketDestination = "/topic/discussion-topics/session/";
 
   private final TopicsRepository topicsRepository;
+  private final SessionsRepository sessionsRepository;
   private final SimpMessagingTemplate webSocketMessagingTemplate;
 
   public BroadcastTopicsServiceImpl(final TopicsRepository topicsRepository,
-      SimpMessagingTemplate webSocketMessagingTemplate) {
+      final SessionsRepository sessionsRepository,
+      final SimpMessagingTemplate webSocketMessagingTemplate) {
     this.topicsRepository = topicsRepository;
+    this.sessionsRepository = sessionsRepository;
     this.webSocketMessagingTemplate = webSocketMessagingTemplate;
   }
 
@@ -34,23 +41,35 @@ public class BroadcastTopicsServiceImpl implements BroadcastTopicsService {
     for (final Object[] objects : votesList) {
       final String text = (String) objects[0];
       final List<String> voters = topicsAndVotersMap.containsKey(text)
-        ? topicsAndVotersMap.get(text)
-        : new ArrayList<>();
-      if(objects[1] != null) {
+          ? topicsAndVotersMap.get(text)
+          : new ArrayList<>();
+      if (objects[1] != null) {
         voters.add((String) objects[1]);
       }
       topicsAndVotersMap.put(text, voters);
     }
 
-    final JSONArray messageJson = new JSONArray();
-    for(final Map.Entry<String, List<String>> entry : topicsAndVotersMap.entrySet()) {
-      messageJson.put(new JSONObject()
+    final JSONArray topicsJson = new JSONArray();
+    for (final Map.Entry<String, List<String>> entry : topicsAndVotersMap.entrySet()) {
+      topicsJson.put(new JSONObject()
           .put("text", entry.getKey())
           .put("voters", new JSONArray(entry.getValue())));
     }
 
-    webSocketMessagingTemplate
-        .convertAndSend(websocketDestination + sessionId, messageJson.toString());
-    return new SuccessOrFailureAndErrorBody(SUCCESS, null);
+    final Optional<SessionsEntity> sessionsEntityOptional = sessionsRepository.findById(sessionId);
+    if (sessionsEntityOptional.isPresent()) {
+      final JSONObject messageJson = new JSONObject()
+          .put("currentTopicEndTime",
+              sessionsEntityOptional.get().getCurrentTopicEndTime() == null
+                  ? JSONObject.NULL
+                  : sessionsEntityOptional.get().getCurrentTopicEndTime())
+          .put("topics", topicsJson);
+
+      webSocketMessagingTemplate
+          .convertAndSend(websocketDestination + sessionId, messageJson.toString());
+      return new SuccessOrFailureAndErrorBody(SUCCESS, null);
+    } else {
+      return new SuccessOrFailureAndErrorBody(FAILURE, "Couldn't find that session");
+    }
   }
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
@@ -9,21 +9,17 @@ import com.leancoffree.backend.enums.SessionStatus;
 import com.leancoffree.backend.repository.SessionsRepository;
 import java.time.Instant;
 import java.util.Optional;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 public class TransitionToDiscussionServiceImpl implements TransitionToDiscussionService {
 
   private final SessionsRepository sessionsRepository;
-  private final SimpMessagingTemplate webSocketMessagingTemplate;
   private final BroadcastTopicsService broadcastTopicsService;
 
   public TransitionToDiscussionServiceImpl(final SessionsRepository sessionsRepository,
-      final SimpMessagingTemplate webSocketMessagingTemplate,
       final BroadcastTopicsService broadcastTopicsService) {
     this.sessionsRepository = sessionsRepository;
-    this.webSocketMessagingTemplate = webSocketMessagingTemplate;
     this.broadcastTopicsService = broadcastTopicsService;
   }
 
@@ -37,8 +33,6 @@ public class TransitionToDiscussionServiceImpl implements TransitionToDiscussion
     sessionsEntity.setSessionStatus(SessionStatus.DISCUSSING);
     sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(180));
     sessionsRepository.save(sessionsEntity);
-    webSocketMessagingTemplate
-        .convertAndSend("/topic/status/session/" + sessionId, "DISCUSSING");
     broadcastTopicsService.broadcastTopics(sessionId);
     return new SuccessOrFailureAndErrorBody(SUCCESS, null);
   }

--- a/backend/src/main/resources/db/V8_AddCurrentTopicEndTimeColumnToSessionsTable.sql
+++ b/backend/src/main/resources/db/V8_AddCurrentTopicEndTimeColumnToSessionsTable.sql
@@ -1,0 +1,2 @@
+alter table sessions
+add column current_topic_end_time timestamp;

--- a/backend/src/main/resources/db/V8_AddCurrentTopicEndTimeColumnToSessionsTable.sql
+++ b/backend/src/main/resources/db/V8_AddCurrentTopicEndTimeColumnToSessionsTable.sql
@@ -1,2 +1,2 @@
 alter table sessions
-add column current_topic_end_time timestamp;
+add column current_topic_end_time timestamp null default null;

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -52,7 +52,10 @@ class DiscussionPage extends React.Component {
     if(this.state.currentTopicSecondsRemaining !== -1) {
       let minutesNum = Math.floor(this.state.currentTopicSecondsRemaining / 60);
       let secondsNum = this.state.currentTopicSecondsRemaining % 60;
-      countdown = <p>{minutesNum} : {secondsNum}</p>
+      if(secondsNum < 10) {
+        secondsNum = ("0" + secondsNum).slice(-2);
+      }
+      countdown = <h5 class="countdown">{minutesNum} : {secondsNum}</h5>
     }
     
     return (

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -7,7 +7,22 @@ class DiscussionPage extends React.Component {
     this.state = {
       topics: props.topics,
       userDisplayName: props.userInfo.displayName,
+      currentTopicSecondsRemaining: -1,
+      currentTopicEndTime: props.currentEndTime
     }
+  }
+
+  componentDidMount() {
+    if(this.state.currentTopicSecondsRemaining === -1 && this.state.currentTopicEndTime !== '' && this.state.currentTopicEndTime !== null && this.state.currentTopicEndTime !== undefined) {
+      let endSeconds = Math.round(new Date(this.state.currentTopicEndTime).getTime() / 1000);
+      let nowSeconds = Math.round(new Date().getTime() / 1000);
+      this.setState({currentTopicSecondsRemaining: Math.max(0, endSeconds - nowSeconds)})
+    }
+    setInterval(() => {
+        let endSeconds = Math.round(new Date(this.state.currentTopicEndTime).getTime() / 1000);
+        let nowSeconds = Math.round(new Date().getTime() / 1000);
+        this.setState({currentTopicSecondsRemaining: Math.max(0, endSeconds - nowSeconds)})
+    }, 500);
   }
 
   getAllTopicCards() {
@@ -32,7 +47,14 @@ class DiscussionPage extends React.Component {
     return topicsElements;
   }
 
-  render() {
+  render() {  
+    let countdown;
+    if(this.state.currentTopicSecondsRemaining !== -1) {
+      let minutesNum = Math.floor(this.state.currentTopicSecondsRemaining / 60);
+      let secondsNum = this.state.currentTopicSecondsRemaining % 60;
+      countdown = <p>{minutesNum} : {secondsNum}</p>
+    }
+    
     return (
       <div class="session-grid-container">
         <div class="discussCards-grid-container">
@@ -41,6 +63,7 @@ class DiscussionPage extends React.Component {
           <div class="currentDiscussionItem">
             <h5 class="currentTopicHeader">Current discussion item</h5>
             <h2 class="currentTopicHeader">{this.state.topics[0].text}</h2>
+            {countdown}
           </div>
 
           <div class="session-grid-item usersSection column3">

--- a/frontend/src/session/Session.js
+++ b/frontend/src/session/Session.js
@@ -79,9 +79,6 @@ class Session extends React.Component {
             }
           }
         );
-        stompClient.subscribe('/topic/status/session/' + this.state.sessionId,
-          (payload) => this.setState({sessionStatus: payload.body})
-        );
         stompClient.subscribe('/topic/users/session/' + this.state.sessionId, 
           (payload) => {
             let updateUsersBody = JSON.parse(payload.body);

--- a/frontend/src/session/Session.js
+++ b/frontend/src/session/Session.js
@@ -203,17 +203,19 @@ class Session extends React.Component {
   }
 
   transitionToDiscussion() {
-    Axios.post(process.env.REACT_APP_BACKEND_BASEURL + "/transition-to-discussion/" + this.state.sessionId, {})
-    .then((response) => {
-      if(response.data.status !== "SUCCESS") {
-        alert(response.data.error);
-      } else {
-        this.setState({sessionStatus: "DISCUSSING"})
-      }
-    })
-    .catch((error) => {
-      alert("Unable to transition to next section\n" + error)
-    })
+    if(this.state.topics.length >= 2) {
+      Axios.post(process.env.REACT_APP_BACKEND_BASEURL + "/transition-to-discussion/" + this.state.sessionId, {})
+      .then((response) => {
+        if(response.data.status !== "SUCCESS") {
+          alert(response.data.error);
+        } else {
+          this.setState({sessionStatus: "DISCUSSING"})
+        }
+      })
+      .catch((error) => {
+        alert("Unable to transition to next section\n" + error)
+      })
+    }
   }
 
   render() {
@@ -228,6 +230,11 @@ class Session extends React.Component {
     }
 
     else if (this.state.sessionStatus === "STARTED") {
+      let nextSectionButton = this.state.topics.length >= 2
+        ? <div class="nextSectionButton">
+            <button onClick={this.transitionToDiscussion}>End voting and go to next section</button>
+          </div>
+        : null;
       return (
         <div class="session-grid-container">
           <div class="session-grid-item cardsSection">
@@ -236,9 +243,7 @@ class Session extends React.Component {
           <div class="session-grid-item usersSection">
             <div>All here:</div>
             <div>{this.getAllHere()}</div>
-            <div class="nextSectionButton">
-              <button onClick={this.transitionToDiscussion}>End voting and go to next section</button>
-            </div>
+            {nextSectionButton}
           </div>
         </div>
       )

--- a/frontend/src/session/session.css
+++ b/frontend/src/session/session.css
@@ -105,6 +105,7 @@
   grid-row: 1;
   grid-column: 2;
   width: 65vw;
+  position: relative;
 }
 
 .column3 {
@@ -119,4 +120,12 @@
 
 .currentTopicHeader{
   text-align: center;
+}
+
+.countdown {
+  text-align: center;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }


### PR DESCRIPTION
* add backend logic:
  * on reception of request to transition endpoint, now will update session in db to have currentTopicEndTime of now + 3 minutes, then will broadcasts topics
  * modify topic broadcasting to include current topic end time, if null then frontend knows to stay on voting page, if populated then it knows to go to discussion page. Thus removed now obsolete status websocket route
* session.js passes the endtime to discussion page which displays it. It calculates the display time every half second, so different users should only ever see a max difference of one unit
* Fixed in this PR: only allow transition to discussion if 2 or more topics provided