### PR TITLE
Fix sorting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stage("Deploy: Frontend") {
       when {
         expression {
-           env.BRANCH_NAME == "fixSorting"
+           env.BRANCH_NAME == "main"
         }
       }
       steps {
@@ -36,7 +36,7 @@ pipeline {
     stage("Deploy: Backend") {
       when {
         expression {
-           env.BRANCH_NAME == "fixSorting"
+           env.BRANCH_NAME == "main"
         }
       }
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stage("Deploy: Frontend") {
       when {
         expression {
-           env.BRANCH_NAME == "main"
+           env.BRANCH_NAME == "fixSorting"
         }
       }
       steps {
@@ -36,7 +36,7 @@ pipeline {
     stage("Deploy: Backend") {
       when {
         expression {
-           env.BRANCH_NAME == "main"
+           env.BRANCH_NAME == "fixSorting"
         }
       }
       steps {

--- a/backend/src/main/java/com/leancoffree/backend/enums/SortTopicsBy.java
+++ b/backend/src/main/java/com/leancoffree/backend/enums/SortTopicsBy.java
@@ -1,0 +1,6 @@
+package com.leancoffree.backend.enums;
+
+public enum SortTopicsBy {
+  CREATION,
+  VOTES
+}

--- a/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionServiceImpl.java
@@ -84,12 +84,11 @@ public class AddUserToSessionServiceImpl implements AddUserToSessionService {
             .error(null)
             .sessionStatus(sessionsEntityOptional.get().getSessionStatus())
             .build();
-      } else {
-        return SessionStatusResponse.builder()
-            .status(FAILURE)
-            .error("How'd that happen? Please try again")
-            .build();
       }
+      return SessionStatusResponse.builder()
+          .status(FAILURE)
+          .error("How'd that happen? Please try again")
+          .build();
     } else {
       return SessionStatusResponse.builder()
           .status(FAILURE)

--- a/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionServiceImpl.java
@@ -1,5 +1,8 @@
 package com.leancoffree.backend.service;
 
+import static com.leancoffree.backend.enums.SessionStatus.DISCUSSING;
+import static com.leancoffree.backend.enums.SortTopicsBy.CREATION;
+import static com.leancoffree.backend.enums.SortTopicsBy.VOTES;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
 
@@ -8,6 +11,7 @@ import com.leancoffree.backend.domain.entity.UsersEntity;
 import com.leancoffree.backend.domain.entity.UsersEntity.UsersId;
 import com.leancoffree.backend.domain.model.RefreshUsersRequest;
 import com.leancoffree.backend.domain.model.SessionStatusResponse;
+import com.leancoffree.backend.enums.SortTopicsBy;
 import com.leancoffree.backend.repository.SessionsRepository;
 import com.leancoffree.backend.repository.UsersRepository;
 import java.util.ArrayList;
@@ -56,38 +60,41 @@ public class AddUserToSessionServiceImpl implements AddUserToSessionService {
       final Optional<List<UsersEntity>> optionalUsersEntityList = usersRepository
           .findBySessionIdAndIsOnlineTrue(sessionId);
 
-      if (optionalUsersEntityList.isPresent()) {
+      final Optional<SessionsEntity> sessionsEntityOptional = sessionsRepository
+          .findById(refreshUsersRequest.getSessionId());
+
+      if (optionalUsersEntityList.isPresent() && sessionsEntityOptional.isPresent()) {
         final List<String> displayNames = new ArrayList<>();
         for (final UsersEntity usersEntity : optionalUsersEntityList.get()) {
           displayNames.add(usersEntity.getDisplayName());
         }
         final String websocketMessageString = new JSONObject()
             .put("displayNames", new JSONArray(displayNames)).toString();
+        final SortTopicsBy sortTopicsBy =
+            sessionsEntityOptional.get().getSessionStatus().equals(DISCUSSING)
+                ? VOTES
+                : CREATION;
+
         webSocketMessagingTemplate
-            .convertAndSend("/topic/users/session/" + refreshUsersRequest.getSessionId(),
-                websocketMessageString);
-        broadcastTopicsService.broadcastTopics(sessionId);
+            .convertAndSend("/topic/users/session/" + sessionId, websocketMessageString);
+        broadcastTopicsService.broadcastTopics(sessionId, sortTopicsBy);
 
-        final Optional<SessionsEntity> sessionsEntityOptional = sessionsRepository
-            .findById(refreshUsersRequest.getSessionId());
-        if (sessionsEntityOptional.isPresent()) {
-          return SessionStatusResponse.builder()
-              .status(SUCCESS)
-              .error(null)
-              .sessionStatus(sessionsEntityOptional.get().getSessionStatus())
-              .build();
-        }
+        return SessionStatusResponse.builder()
+            .status(SUCCESS)
+            .error(null)
+            .sessionStatus(sessionsEntityOptional.get().getSessionStatus())
+            .build();
+      } else {
+        return SessionStatusResponse.builder()
+            .status(FAILURE)
+            .error("How'd that happen? Please try again")
+            .build();
       }
-      return SessionStatusResponse.builder()
-          .status(FAILURE)
-          .error("How'd that happen? Please try again")
-          .build();
-
     } else {
       return SessionStatusResponse.builder()
           .status(FAILURE)
           .error("Display name already in use in session")
           .build();
-    } }
-
+    }
+  }
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionServiceImpl.java
@@ -77,7 +77,7 @@ public class AddUserToSessionServiceImpl implements AddUserToSessionService {
 
         webSocketMessagingTemplate
             .convertAndSend("/topic/users/session/" + sessionId, websocketMessageString);
-        broadcastTopicsService.broadcastTopics(sessionId, sortTopicsBy);
+        broadcastTopicsService.broadcastTopics(sessionId, sortTopicsBy, false);
 
         return SessionStatusResponse.builder()
             .status(SUCCESS)

--- a/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsService.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsService.java
@@ -6,5 +6,5 @@ import com.leancoffree.backend.enums.SortTopicsBy;
 public interface BroadcastTopicsService {
 
   SuccessOrFailureAndErrorBody broadcastTopics(final String sessionId,
-      final SortTopicsBy sortTopicsBy);
+      final SortTopicsBy sortTopicsBy, final boolean shouldUpdateTopicStatus);
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsService.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsService.java
@@ -1,8 +1,10 @@
 package com.leancoffree.backend.service;
 
 import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.enums.SortTopicsBy;
 
 public interface BroadcastTopicsService {
 
-  SuccessOrFailureAndErrorBody broadcastTopics(final String sessionId);
+  SuccessOrFailureAndErrorBody broadcastTopics(final String sessionId,
+      final SortTopicsBy sortTopicsBy);
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsServiceImpl.java
@@ -5,6 +5,7 @@ import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
 
 import com.leancoffree.backend.domain.entity.SessionsEntity;
 import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.enums.SortTopicsBy;
 import com.leancoffree.backend.repository.SessionsRepository;
 import com.leancoffree.backend.repository.TopicsRepository;
 import java.util.ArrayList;
@@ -18,7 +19,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.springframework.data.util.Pair;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
@@ -39,9 +39,15 @@ public class BroadcastTopicsServiceImpl implements BroadcastTopicsService {
     this.webSocketMessagingTemplate = webSocketMessagingTemplate;
   }
 
-  public SuccessOrFailureAndErrorBody broadcastTopics(final String sessionId) {
+  public SuccessOrFailureAndErrorBody broadcastTopics(final String sessionId,
+      final SortTopicsBy sortTopicsBy) {
 
-    final List<Object[]> votesList = topicsRepository.findAllVotes(sessionId);
+    final List<Object[]> votesList;
+    if(SortTopicsBy.VOTES.equals(sortTopicsBy)) {
+      votesList = topicsRepository.findAllVotes(sessionId);
+    } else {
+      votesList = ;
+    }
 
     final Optional<SessionsEntity> sessionsEntityOptional = sessionsRepository.findById(sessionId);
     if (sessionsEntityOptional.isPresent()) {

--- a/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsServiceImpl.java
@@ -1,14 +1,23 @@
 package com.leancoffree.backend.service;
 
+import static com.leancoffree.backend.enums.SortTopicsBy.CREATION;
+import static com.leancoffree.backend.enums.SortTopicsBy.VOTES;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
+import static com.leancoffree.backend.enums.TopicStatus.DISCUSSING;
 
 import com.leancoffree.backend.domain.entity.SessionsEntity;
+import com.leancoffree.backend.domain.entity.TopicsEntity;
 import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
 import com.leancoffree.backend.enums.SortTopicsBy;
+import com.leancoffree.backend.enums.TopicStatus;
 import com.leancoffree.backend.repository.SessionsRepository;
 import com.leancoffree.backend.repository.TopicsRepository;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,14 +49,9 @@ public class BroadcastTopicsServiceImpl implements BroadcastTopicsService {
   }
 
   public SuccessOrFailureAndErrorBody broadcastTopics(final String sessionId,
-      final SortTopicsBy sortTopicsBy) {
+      final SortTopicsBy sortTopicsBy, boolean shouldUpdateTopicStatus) {
 
-    final List<Object[]> votesList;
-    if(SortTopicsBy.VOTES.equals(sortTopicsBy)) {
-      votesList = topicsRepository.findAllVotes(sessionId);
-    } else {
-      votesList = ;
-    }
+    final List<Object[]> votesList = topicsRepository.findAllVotes(sessionId);
 
     final Optional<SessionsEntity> sessionsEntityOptional = sessionsRepository.findById(sessionId);
     if (sessionsEntityOptional.isPresent()) {
@@ -61,28 +65,54 @@ public class BroadcastTopicsServiceImpl implements BroadcastTopicsService {
         if (objects[1] != null) {
           voters.add((String) objects[1]);
         }
+
         topicsAndVotersMap
-            .put(text, new TopicDetails((String) objects[3], (String) objects[2], voters));
+            .put(text, new TopicDetails(text, (String) objects[3], (String) objects[2], voters,
+                ((Timestamp) objects[4]).toInstant()));
       }
 
+      final List<TopicDetails> topicDetailsList = new ArrayList<>();
+      for (final Map.Entry<String, TopicDetails> entry : topicsAndVotersMap.entrySet()) {
+        topicDetailsList.add(entry.getValue());
+      }
+
+      if (VOTES.equals(sortTopicsBy)) {
+        topicDetailsList.sort((a, b) -> b.getVoters().size() - a.getVoters().size());
+      } else if (CREATION.equals(sortTopicsBy)) {
+        topicDetailsList.sort(Comparator.comparing(TopicDetails::getCreationDate));
+      }
+
+      if(shouldUpdateTopicStatus) {
+        final TopicDetails currentDiscussionItem = topicDetailsList.get(0);
+        currentDiscussionItem.setTopicStatus(DISCUSSING.toString());
+        topicDetailsList.set(0, currentDiscussionItem);
+        final TopicsEntity topicsEntity = TopicsEntity.builder()
+            .sessionId(sessionId)
+            .text(currentDiscussionItem.getText())
+            .topicStatus(TopicStatus.valueOf(currentDiscussionItem.getTopicStatus()))
+            .displayName(currentDiscussionItem.getAuthorDisplayName())
+            .createdTimestamp(currentDiscussionItem.getCreationDate())
+            .build();
+        topicsRepository.save(topicsEntity);
+      }
+
+      final JSONObject currentDiscussionItem = new JSONObject();
       final JSONArray discussionBacklogTopicsJson = new JSONArray();
       final JSONArray discussedTopicsJson = new JSONArray();
-      final JSONObject currentDiscussionItem = new JSONObject();
-      for (final Map.Entry<String, TopicDetails> entry : topicsAndVotersMap
-          .entrySet()) {
-        if (entry.getValue().getTopicStatus().equals("QUEUED")) {
+      for (final TopicDetails topicDetails : topicDetailsList) {
+        if (topicDetails.getTopicStatus().equals("QUEUED")) {
           discussionBacklogTopicsJson.put(new JSONObject()
-              .put("text", entry.getKey())
-              .put("authorDisplayName", entry.getValue().getAuthorDisplayName())
-              .put("voters", new JSONArray(entry.getValue().getVoters())));
-        } else if (entry.getValue().getTopicStatus().equals("DISCUSSED")) {
+              .put("text", topicDetails.getText())
+              .put("authorDisplayName", topicDetails.getAuthorDisplayName())
+              .put("voters", new JSONArray(topicDetails.getVoters())));
+        } else if (topicDetails.getTopicStatus().equals("DISCUSSED")) {
           discussedTopicsJson.put(new JSONObject()
-              .put("text", entry.getKey())
-              .put("voters", new JSONArray(entry.getValue().getVoters())));
-        } else if (entry.getValue().getTopicStatus().equals("DISCUSSING")) {
-          currentDiscussionItem.put("text", entry.getKey())
-              .put("voters", new JSONArray(entry.getValue().getVoters()))
-              .put("authorDisplayName", entry.getValue().getAuthorDisplayName())
+              .put("text", topicDetails.getText())
+              .put("voters", new JSONArray(topicDetails.getVoters())));
+        } else if (topicDetails.getTopicStatus().equals("DISCUSSING")) {
+          currentDiscussionItem.put("text", topicDetails.getText())
+              .put("voters", new JSONArray(topicDetails.getVoters()))
+              .put("authorDisplayName", topicDetails.getAuthorDisplayName())
               .put("endTime", sessionsEntityOptional.get().getCurrentTopicEndTime() == null
                   ? JSONObject.NULL
                   : sessionsEntityOptional.get().getCurrentTopicEndTime());
@@ -108,8 +138,10 @@ public class BroadcastTopicsServiceImpl implements BroadcastTopicsService {
   @NoArgsConstructor
   private static class TopicDetails {
 
+    private String text;
     private String authorDisplayName;
     private String topicStatus;
     private List<String> voters;
+    private Instant creationDate;
   }
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/PostVoteServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/PostVoteServiceImpl.java
@@ -47,6 +47,6 @@ public class PostVoteServiceImpl implements PostVoteService {
           .deleteByVoterSessionIdAndTextAndVoterDisplayName(postVoteRequest.getSessionId(),
               postVoteRequest.getText(), postVoteRequest.getVoterDisplayName());
     }
-    return broadcastTopicsService.broadcastTopics(postVoteRequest.getSessionId(), CREATION);
+    return broadcastTopicsService.broadcastTopics(postVoteRequest.getSessionId(), CREATION, false);
   }
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/PostVoteServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/PostVoteServiceImpl.java
@@ -1,5 +1,6 @@
 package com.leancoffree.backend.service;
 
+import static com.leancoffree.backend.enums.SortTopicsBy.CREATION;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.VoteType.CAST;
 
@@ -46,6 +47,6 @@ public class PostVoteServiceImpl implements PostVoteService {
           .deleteByVoterSessionIdAndTextAndVoterDisplayName(postVoteRequest.getSessionId(),
               postVoteRequest.getText(), postVoteRequest.getVoterDisplayName());
     }
-    return broadcastTopicsService.broadcastTopics(postVoteRequest.getSessionId());
+    return broadcastTopicsService.broadcastTopics(postVoteRequest.getSessionId(), CREATION);
   }
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
@@ -60,7 +60,7 @@ public class RefreshTopicsServiceImpl implements RefreshTopicsService {
         topicsRepository.save(nextTopicsEntity);
 
         final SessionsEntity sessionsEntity = sessionsEntityOptional.get();
-        sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(5));
+        sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(180));
         sessionsRepository.save(sessionsEntity);
 
         broadcastTopicsService.broadcastTopics(refreshTopicsRequest.getSessionId(), VOTES, false);

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
@@ -63,7 +63,7 @@ public class RefreshTopicsServiceImpl implements RefreshTopicsService {
         sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(5));
         sessionsRepository.save(sessionsEntity);
 
-        broadcastTopicsService.broadcastTopics(refreshTopicsRequest.getSessionId(), VOTES);
+        broadcastTopicsService.broadcastTopics(refreshTopicsRequest.getSessionId(), VOTES, false);
         return new SuccessOrFailureAndErrorBody(SUCCESS, null);
       }
     } else if (FINISH.equals(refreshTopicsRequest.getCommand())) {

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
@@ -2,6 +2,7 @@ package com.leancoffree.backend.service;
 
 import static com.leancoffree.backend.enums.RefreshTopicsCommand.FINISH;
 import static com.leancoffree.backend.enums.RefreshTopicsCommand.NEXT;
+import static com.leancoffree.backend.enums.SortTopicsBy.VOTES;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
 import static com.leancoffree.backend.enums.TopicStatus.DISCUSSED;
@@ -12,6 +13,7 @@ import com.leancoffree.backend.domain.entity.TopicsEntity;
 import com.leancoffree.backend.domain.entity.TopicsEntity.TopicsId;
 import com.leancoffree.backend.domain.model.RefreshTopicsRequest;
 import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.enums.SortTopicsBy;
 import com.leancoffree.backend.repository.SessionsRepository;
 import com.leancoffree.backend.repository.TopicsRepository;
 import java.time.Instant;
@@ -61,7 +63,7 @@ public class RefreshTopicsServiceImpl implements RefreshTopicsService {
         sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(5));
         sessionsRepository.save(sessionsEntity);
 
-        broadcastTopicsService.broadcastTopics(refreshTopicsRequest.getSessionId());
+        broadcastTopicsService.broadcastTopics(refreshTopicsRequest.getSessionId(), VOTES);
         return new SuccessOrFailureAndErrorBody(SUCCESS, null);
       }
     } else if (FINISH.equals(refreshTopicsRequest.getCommand())) {

--- a/backend/src/main/java/com/leancoffree/backend/service/SubmitTopicServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/SubmitTopicServiceImpl.java
@@ -40,7 +40,7 @@ public class SubmitTopicServiceImpl implements SubmitTopicService {
           .topicStatus(QUEUED)
           .displayName(submitTopicRequest.getDisplayName())
           .build());
-      return broadcastTopicsService.broadcastTopics(sessionId, CREATION);
+      return broadcastTopicsService.broadcastTopics(sessionId, CREATION, false);
     } else {
       return new SuccessOrFailureAndErrorBody(FAILURE, "Topic already submitted");
     }

--- a/backend/src/main/java/com/leancoffree/backend/service/SubmitTopicServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/SubmitTopicServiceImpl.java
@@ -1,5 +1,6 @@
 package com.leancoffree.backend.service;
 
+import static com.leancoffree.backend.enums.SortTopicsBy.CREATION;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.TopicStatus.QUEUED;
 
@@ -7,7 +8,6 @@ import com.leancoffree.backend.domain.entity.TopicsEntity;
 import com.leancoffree.backend.domain.entity.TopicsEntity.TopicsId;
 import com.leancoffree.backend.domain.model.SubmitTopicRequest;
 import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
-import com.leancoffree.backend.enums.TopicStatus;
 import com.leancoffree.backend.repository.TopicsRepository;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
@@ -40,7 +40,7 @@ public class SubmitTopicServiceImpl implements SubmitTopicService {
           .topicStatus(QUEUED)
           .displayName(submitTopicRequest.getDisplayName())
           .build());
-      return broadcastTopicsService.broadcastTopics(sessionId);
+      return broadcastTopicsService.broadcastTopics(sessionId, CREATION);
     } else {
       return new SuccessOrFailureAndErrorBody(FAILURE, "Topic already submitted");
     }

--- a/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
@@ -32,7 +32,7 @@ public class TransitionToDiscussionServiceImpl implements TransitionToDiscussion
 
     final SessionsEntity sessionsEntity = sessionsEntityOptional.get();
     sessionsEntity.setSessionStatus(SessionStatus.DISCUSSING);
-    sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(5));
+    sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(180));
     sessionsRepository.save(sessionsEntity);
 
     broadcastTopicsService.broadcastTopics(sessionId, VOTES, true);

--- a/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
@@ -3,18 +3,12 @@ package com.leancoffree.backend.service;
 import static com.leancoffree.backend.enums.SortTopicsBy.VOTES;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
-import static com.leancoffree.backend.enums.TopicStatus.DISCUSSING;
 
 import com.leancoffree.backend.domain.entity.SessionsEntity;
-import com.leancoffree.backend.domain.entity.TopicsEntity;
 import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
 import com.leancoffree.backend.enums.SessionStatus;
-import com.leancoffree.backend.enums.SortTopicsBy;
 import com.leancoffree.backend.repository.SessionsRepository;
-import com.leancoffree.backend.repository.TopicsRepository;
-import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 
@@ -22,15 +16,12 @@ import org.springframework.stereotype.Service;
 public class TransitionToDiscussionServiceImpl implements TransitionToDiscussionService {
 
   private final SessionsRepository sessionsRepository;
-  private final TopicsRepository topicsRepository;
   private final BroadcastTopicsService broadcastTopicsService;
 
   public TransitionToDiscussionServiceImpl(final SessionsRepository sessionsRepository,
-      final BroadcastTopicsService broadcastTopicsService,
-      final TopicsRepository topicsRepository) {
+      final BroadcastTopicsService broadcastTopicsService) {
     this.sessionsRepository = sessionsRepository;
     this.broadcastTopicsService = broadcastTopicsService;
-    this.topicsRepository = topicsRepository;
   }
 
   public SuccessOrFailureAndErrorBody transitionToDiscussion(final String sessionId) {
@@ -44,17 +35,8 @@ public class TransitionToDiscussionServiceImpl implements TransitionToDiscussion
     sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(5));
     sessionsRepository.save(sessionsEntity);
 
-    final List<Object[]> resultObjects = topicsRepository.findAllVotes(sessionId);
-    final TopicsEntity topicsEntity = TopicsEntity.builder()
-        .sessionId(sessionId)
-        .text((String) resultObjects.get(0)[0])
-        .topicStatus(DISCUSSING)
-        .displayName((String) resultObjects.get(0)[3])
-        .createdTimestamp(((Timestamp) resultObjects.get(0)[4]).toInstant())
-        .build();
-    topicsRepository.save(topicsEntity);
+    broadcastTopicsService.broadcastTopics(sessionId, VOTES, true);
 
-    broadcastTopicsService.broadcastTopics(sessionId, VOTES);
     return new SuccessOrFailureAndErrorBody(SUCCESS, null);
   }
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.leancoffree.backend.service;
 
+import static com.leancoffree.backend.enums.SortTopicsBy.VOTES;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
 import static com.leancoffree.backend.enums.TopicStatus.DISCUSSING;
@@ -8,6 +9,7 @@ import com.leancoffree.backend.domain.entity.SessionsEntity;
 import com.leancoffree.backend.domain.entity.TopicsEntity;
 import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
 import com.leancoffree.backend.enums.SessionStatus;
+import com.leancoffree.backend.enums.SortTopicsBy;
 import com.leancoffree.backend.repository.SessionsRepository;
 import com.leancoffree.backend.repository.TopicsRepository;
 import java.sql.Timestamp;
@@ -52,7 +54,7 @@ public class TransitionToDiscussionServiceImpl implements TransitionToDiscussion
         .build();
     topicsRepository.save(topicsEntity);
 
-    broadcastTopicsService.broadcastTopics(sessionId);
+    broadcastTopicsService.broadcastTopics(sessionId, VOTES);
     return new SuccessOrFailureAndErrorBody(SUCCESS, null);
   }
 }

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,3 +1,4 @@
 REACT_APP_BACKEND_BASEURL=https://leancoffree.com:8085
 REACT_APP_FRONTEND_BASEURL=https://leancoffree.com
 REACT_APP_SESSION_REGEX=https://leancoffree.com/session/[0-9, a-f]{8}-[0-9, a-f]{4}-[0-9, a-f]{4}-[0-9, a-f]{4}-[0-9, a-f]{12}
+REACT_APP_STOMP_CLIENT_DEBUG=false

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -68,7 +68,7 @@ class DiscussionPage extends React.Component {
         let text = allTopics[i].text;
         let votes = allTopics[i].voters.length;
         topicsElements.push(
-          <div key={i.toString()} class="cardItem discussionCardItem" style={{gridRow: i}}>
+          <div key={i.toString()} class="cardItem discussionCardItem" style={{gridRow: i + 1}}>
             <p class="topicsText">{text}</p>
             <p class="votesText">Votes: {votes}</p>
           </div>

--- a/frontend/src/session/Session.js
+++ b/frontend/src/session/Session.js
@@ -68,6 +68,9 @@ class Session extends React.Component {
     var SockJS = require('sockjs-client')
     SockJS = new SockJS(process.env.REACT_APP_BACKEND_BASEURL + '/lean-coffree')
     stompClient = Stomp.over(SockJS);
+    if(process.env.REACT_APP_STOMP_CLIENT_DEBUG === 'false') {
+      stompClient.debug = null;
+    }
     stompClient.connect({}, 
       (frame) => {
         stompClient.subscribe('/topic/discussion-topics/session/' + this.state.sessionId, 

--- a/frontend/src/session/Session.js
+++ b/frontend/src/session/Session.js
@@ -75,7 +75,11 @@ class Session extends React.Component {
             if(JSON.parse(payload.body).currentDiscussionItem.text === undefined) {
               this.setState({topics: JSON.parse(payload.body)});
             } else {
-              this.setState({topics: JSON.parse(payload.body), currentTopicEndTime: JSON.parse(payload.body).currentDiscussionItem.endTime}, () => this.setState({sessionStatus: "DISCUSSING"}));
+              this.setState({topics: JSON.parse(payload.body), currentTopicEndTime: JSON.parse(payload.body).currentDiscussionItem.endTime}, () => {
+                if(this.state.sessionStatus !== "" && this.state.sessionStatus !== "ASK_FOR_USERNAME") {
+                  this.setState({sessionStatus: "DISCUSSING"});
+                }
+              });
             }
           }
         );


### PR DESCRIPTION
* Update broadcast topics logic to properly handle sorting by either creation date or most votes, I don't think its efficient, but under 0 load who cares, I feel like this would be a lot easier with mongo instead of mysql...
* fix frontend grid row number as i + 1, lord knows how many hours I wasted thinking my sorting was completely fucked
* simplify process for transitioning, now broadcast service will make the topic status update as it has all the info already
* services which broadcast topics now provide sorting strategy (for addUser this is based on session status)
* update frontend to not log stomp client messages in production
* fix frontend issue where before: when waiting for user display name input, user would be automatically transitioned to discussion along with rest of session. now waits properly and then goes to discussion page properly
