### PR TITLE
Fix to allow users to join sessions of any state once state not waiting to start

### DIFF
--- a/frontend/src/splash/JoinSessionModal.js
+++ b/frontend/src/splash/JoinSessionModal.js
@@ -32,7 +32,7 @@ class JoinSessionModal extends React.Component {
 
   isVerificationResponseValid(response, sessionGuid) {
     return response.data.verificationStatus === "VERIFICATION_SUCCESS" && response.data.sessionDetails.sessionId === sessionGuid &&
-    response.data.sessionDetails.sessionStatus === "STARTED";
+    response.data.sessionDetails.sessionStatus !== "WAITING_TO_START";
   }
 
   getSessionGuidFromUrlOrReturnNullIfInvalid(sessionUrl) {


### PR DESCRIPTION
Previously a user could only join a session from the modal if the session was STARTED, but now there is DISCUSSING and soon to be FINISHED, all of which are valid to join in. Now just checking that status !== WAITING_TO_START, all other statuses are valid.