### PR TITLE
add finish session functionality

### DIFF
--- a/backend/src/main/java/com/leancoffree/backend/repository/TopicsRepository.java
+++ b/backend/src/main/java/com/leancoffree/backend/repository/TopicsRepository.java
@@ -3,17 +3,28 @@ package com.leancoffree.backend.repository;
 import com.leancoffree.backend.domain.entity.TopicsEntity;
 import com.leancoffree.backend.domain.entity.TopicsEntity.TopicsId;
 import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
 public interface TopicsRepository extends CrudRepository<TopicsEntity, TopicsId> {
 
-  @Query(value = "SELECT topics.text, votes.voter_display_name, topics.status, topics.display_name, topics.created_timestamp"
-      + " FROM topics"
-      + " LEFT JOIN votes ON topics.session_id = votes.topic_author_session_id AND topics.text = votes.topic_text"
-      + " WHERE  topics.session_id = :sessionId"
-      + " ORDER BY topics.created_timestamp",
+  @Query(value =
+      "SELECT topics.text, votes.voter_display_name, topics.status, topics.display_name, topics.created_timestamp"
+          + " FROM topics"
+          + " LEFT JOIN votes ON topics.session_id = votes.topic_author_session_id AND topics.text = votes.topic_text"
+          + " WHERE  topics.session_id = :sessionId"
+          + " ORDER BY topics.created_timestamp",
       nativeQuery = true)
   List<Object[]> findAllVotes(@Param("sessionId") final String sessionId);
+
+  @Modifying
+  @Query(value = "UPDATE topics " +
+      "SET status = :command " +
+      "WHERE text = :text and session_id = :sessionId and display_name = :displayName",
+      nativeQuery = true)
+  void updateStatusByTextAndSessionIdAndDisplayName(@Param("command") final String command,
+      @Param("text") final String text, @Param("sessionId") final String sessionId,
+      @Param("displayName") final String displayName);
 }

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -77,7 +77,7 @@ class DiscussionPage extends React.Component {
     return topicsElements;
   }
 
-  getDiscussedCards() {
+  getDiscussedCards(isFinished) {
     if(this.state.topics.discussedTopics !== undefined && this.state.topics.discussedTopics.length !== 0) {
       let allDiscussedTopicsElements = [];
       for(let i = 0; i <= this.state.topics.discussedTopics.length; i++) {
@@ -94,11 +94,19 @@ class DiscussionPage extends React.Component {
         }
       }
 
-      return (
-        <div class="disccussedItemsSection">
-          {allDiscussedTopicsElements}
-        </div>
-      )
+      if(!isFinished) {
+        return (
+          <div class="discussedItemsSection">
+            {allDiscussedTopicsElements}
+          </div>
+        )
+      } else {
+        return (
+          <div class="discussedItemsSection column1">
+            {allDiscussedTopicsElements}
+          </div>
+        )
+      }
     }
   }
 
@@ -122,19 +130,29 @@ class DiscussionPage extends React.Component {
     let currentDiscussionItem = this.state.topics.currentDiscussionItem.text === undefined
       ? "Session completed!"
       : this.state.topics.currentDiscussionItem.text;
-      
-    return (
-      <div class="session-grid-container">
-        <div class="discussCards-grid-container">
-          {this.getAllTopicCards()}
-        </div>
-        <div class="currentDiscussionItem">
+
+    let allTopicCards = this.getAllTopicCards();
+    let allTopicCardsContainer = allTopicCards.length === 0
+      ? null
+      : <div class="discussCards-grid-container">{allTopicCards}</div>;
+
+    let currentDiscussionItemContainer = allTopicCardsContainer === null 
+      ? <div class="currentDiscussionItem column1">
           <h5 class="currentTopicHeader">{currentDiscussionItemHeader}</h5>
           <h2 class="currentTopicHeader">{currentDiscussionItem}</h2>
           {countdown}
         </div>
-
-        {this.getDiscussedCards()}
+      : <div class="currentDiscussionItem">
+          <h5 class="currentTopicHeader">{currentDiscussionItemHeader}</h5>
+          <h2 class="currentTopicHeader">{currentDiscussionItem}</h2>
+          {countdown}
+        </div>;
+      
+    return (
+      <div class="session-grid-container">
+        {allTopicCardsContainer}
+        {currentDiscussionItemContainer}
+        {this.getDiscussedCards(allTopicCardsContainer === null)}
 
         <div class="session-grid-item usersSection column3">
           <div>All here:</div>

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -123,11 +123,11 @@ class DiscussionPage extends React.Component {
       }
     }
 
-    let currentDiscussionItemHeader = this.state.topics.currentDiscussionItem.text === undefined
+    let currentDiscussionItemHeader = this.state.topics.currentDiscussionItem === undefined || this.state.topics.currentDiscussionItem.text === undefined
       ? null
       : "Current discussion item";
     
-    let currentDiscussionItem = this.state.topics.currentDiscussionItem.text === undefined
+    let currentDiscussionItem = this.state.topics.currentDiscussionItem === undefined || this.state.topics.currentDiscussionItem.text === undefined
       ? "Session completed!"
       : this.state.topics.currentDiscussionItem.text;
 

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -32,7 +32,7 @@ class DiscussionPage extends React.Component {
             if(this.state.topics.discussionBacklogTopics.length !== 0) {
               body = {command: "NEXT", sessionId: this.props.sessionId, currentTopicText: this.state.topics.currentDiscussionItem.text, nextTopicText: this.state.topics.discussionBacklogTopics[0].text, currentTopicAuthorDisplayName: this.state.topics.currentDiscussionItem.authorDisplayName, nextTopicAuthorDisplayName: this.state.topics.discussionBacklogTopics[0].authorDisplayName};
             } else {
-              body = {command: "FINISH", sessionId: this.props.sessionId, currentTopicText: this.state.topics.currentDiscussionItem.text, displayName: this.state.userDisplayName, currentTopicAuthorDisplayName: this.state.topics.currentDiscussionItem.authorDisplayName};
+              body = {command: "FINISH", sessionId: this.props.sessionId, currentTopicText: this.state.topics.currentDiscussionItem.text, currentTopicAuthorDisplayName: this.state.topics.currentDiscussionItem.authorDisplayName};
             }
             Axios.post(process.env.REACT_APP_BACKEND_BASEURL + "/refresh-topics", body)
               .then((response) => {
@@ -107,14 +107,20 @@ class DiscussionPage extends React.Component {
     if(this.state.currentTopicSecondsRemaining !== -1) {
       let minutesNum = Math.floor(this.state.currentTopicSecondsRemaining / 60);
       let secondsNum = this.state.currentTopicSecondsRemaining % 60;
-      if(secondsNum < 10) {
-        secondsNum = ("0" + secondsNum).slice(-2);
+      if(!isNaN(minutesNum) && !isNaN(secondsNum)) {
+        if(secondsNum < 10) {
+          secondsNum = ("0" + secondsNum).slice(-2);
+        }
+        countdown = <h5 class="countdown">{minutesNum} : {secondsNum}</h5>
       }
-      countdown = <h5 class="countdown">{minutesNum} : {secondsNum}</h5>
     }
-    
-    let currentDiscussionItem = this.state.topics.currentDiscussionItem === undefined
+
+    let currentDiscussionItemHeader = this.state.topics.currentDiscussionItem.text === undefined
       ? null
+      : "Current discussion item";
+    
+    let currentDiscussionItem = this.state.topics.currentDiscussionItem.text === undefined
+      ? "Session completed!"
       : this.state.topics.currentDiscussionItem.text;
       
     return (
@@ -123,7 +129,7 @@ class DiscussionPage extends React.Component {
           {this.getAllTopicCards()}
         </div>
         <div class="currentDiscussionItem">
-          <h5 class="currentTopicHeader">Current discussion item</h5>
+          <h5 class="currentTopicHeader">{currentDiscussionItemHeader}</h5>
           <h2 class="currentTopicHeader">{currentDiscussionItem}</h2>
           {countdown}
         </div>

--- a/frontend/src/session/session.css
+++ b/frontend/src/session/session.css
@@ -132,14 +132,18 @@
   right: 0;
 }
 
-.disccussedItemsSection {
+.discussedItemsSection {
   grid-row: 2;
   grid-column: 2;
   border-top: solid black 1px;
   max-height: 40vh;
-  width: 65vw;
   overflow: scroll;
   display: grid;
+}
+
+.column1 {
+  grid-column: 1;
+  width: 85vw;
 }
 
 .row1{


### PR DESCRIPTION
Implement backend finish session functionality by marking the current item as discussed and then broadcasting all topics (which will all have status of DISCUSSED). Cleaned up next topic logic at the same time by adding repo method to simplify updating topic status.

cleanup frontend display of finished session for NaN timer and showing finished message

Added functionality to close the empty left discussion backlog column once empty, what was the middle column will stretch to become column 1 while users column says 3 it really becomes 2. 