### PR TITLE
Add drag-and-drop reordering of topics functionality (moderator only)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stage("Deploy: Frontend") {
       when {
         expression {
-           env.BRANCH_NAME == "main"
+           env.BRANCH_NAME == "implementModeratorReorderDiscussionTopics"
         }
       }
       steps {
@@ -36,7 +36,7 @@ pipeline {
     stage("Deploy: Backend") {
       when {
         expression {
-           env.BRANCH_NAME == "main"
+           env.BRANCH_NAME == "implementModeratorReorderDiscussionTopics"
         }
       }
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stage("Deploy: Frontend") {
       when {
         expression {
-           env.BRANCH_NAME == "implementModeratorReorderDiscussionTopics"
+           env.BRANCH_NAME == "main"
         }
       }
       steps {
@@ -36,7 +36,7 @@ pipeline {
     stage("Deploy: Backend") {
       when {
         expression {
-           env.BRANCH_NAME == "implementModeratorReorderDiscussionTopics"
+           env.BRANCH_NAME == "main"
         }
       }
       steps {

--- a/backend/src/main/java/com/leancoffree/backend/controller/ReorderTopicsController.java
+++ b/backend/src/main/java/com/leancoffree/backend/controller/ReorderTopicsController.java
@@ -1,0 +1,49 @@
+package com.leancoffree.backend.controller;
+
+import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
+
+import com.leancoffree.backend.domain.model.ReorderTopicsRequest;
+import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.service.ReorderTopicsService;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ReorderTopicsController {
+
+  private final ReorderTopicsService reorderTopicsService;
+
+  public ReorderTopicsController(final ReorderTopicsService reorderTopicsService) {
+    this.reorderTopicsService = reorderTopicsService;
+  }
+
+  @CrossOrigin
+  @PostMapping("/reorder")
+  public ResponseEntity<SuccessOrFailureAndErrorBody> reorderTopicsEndpoint(
+      final @Valid @RequestBody ReorderTopicsRequest reorderTopicsRequest, final Errors errors) {
+
+    if (errors.hasErrors()) {
+      return buildValidationErrorsResponse(errors);
+    }
+
+    return ResponseEntity.ok(reorderTopicsService.reorderTopics(reorderTopicsRequest));
+  }
+
+  private ResponseEntity<SuccessOrFailureAndErrorBody> buildValidationErrorsResponse(
+      final Errors errors) {
+    final List<String> errorsList = new ArrayList<>();
+    for (final ObjectError error : errors.getAllErrors()) {
+      errorsList.add(error.getDefaultMessage());
+    }
+    return ResponseEntity
+        .ok(new SuccessOrFailureAndErrorBody(FAILURE, String.join(", ", errorsList)));
+  }
+}

--- a/backend/src/main/java/com/leancoffree/backend/domain/entity/TopicsEntity.java
+++ b/backend/src/main/java/com/leancoffree/backend/domain/entity/TopicsEntity.java
@@ -48,6 +48,9 @@ public class TopicsEntity {
   @Column(name = "status")
   private TopicStatus topicStatus;
 
+  @Column(name = "y_index")
+  private Integer yIndex;
+
   @Data
   @Builder
   @AllArgsConstructor

--- a/backend/src/main/java/com/leancoffree/backend/domain/entity/TopicsEntity.java
+++ b/backend/src/main/java/com/leancoffree/backend/domain/entity/TopicsEntity.java
@@ -51,6 +51,9 @@ public class TopicsEntity {
   @Column(name = "y_index")
   private Integer verticalIndex;
 
+  @Column(name = "finished_at")
+  private Instant finishedAt;
+
   @Data
   @Builder
   @AllArgsConstructor

--- a/backend/src/main/java/com/leancoffree/backend/domain/entity/TopicsEntity.java
+++ b/backend/src/main/java/com/leancoffree/backend/domain/entity/TopicsEntity.java
@@ -49,7 +49,7 @@ public class TopicsEntity {
   private TopicStatus topicStatus;
 
   @Column(name = "y_index")
-  private Integer yIndex;
+  private Integer verticalIndex;
 
   @Data
   @Builder

--- a/backend/src/main/java/com/leancoffree/backend/domain/model/ReorderTopicsRequest.java
+++ b/backend/src/main/java/com/leancoffree/backend/domain/model/ReorderTopicsRequest.java
@@ -1,0 +1,27 @@
+package com.leancoffree.backend.domain.model;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReorderTopicsRequest {
+
+  @Size(min = 1, max = 100, message = "sessionId should be between 1-500 chars")
+  @NotBlank(message = "sessionId should not be blank")
+  private String sessionId;
+
+  @Size(min = 1, max = 500, message = "submissionText should be between 1-500 chars")
+  @NotBlank(message = "submissionText should not be null")
+  private String text;
+
+  @NotNull(message = "newIndex should not be null")
+  private Integer newIndex;
+}

--- a/backend/src/main/java/com/leancoffree/backend/enums/SortTopicsBy.java
+++ b/backend/src/main/java/com/leancoffree/backend/enums/SortTopicsBy.java
@@ -2,5 +2,5 @@ package com.leancoffree.backend.enums;
 
 public enum SortTopicsBy {
   CREATION,
-  VOTES
+  Y_INDEX
 }

--- a/backend/src/main/java/com/leancoffree/backend/repository/TopicsRepository.java
+++ b/backend/src/main/java/com/leancoffree/backend/repository/TopicsRepository.java
@@ -2,6 +2,7 @@ package com.leancoffree.backend.repository;
 
 import com.leancoffree.backend.domain.entity.TopicsEntity;
 import com.leancoffree.backend.domain.entity.TopicsEntity.TopicsId;
+import java.sql.Timestamp;
 import java.util.List;
 import javax.transaction.Transactional;
 import org.springframework.data.jpa.repository.Modifying;
@@ -12,7 +13,7 @@ import org.springframework.data.repository.query.Param;
 public interface TopicsRepository extends CrudRepository<TopicsEntity, TopicsId> {
 
   @Query(value =
-      "SELECT topics.text, votes.voter_display_name, topics.status, topics.display_name, topics.created_timestamp, topics.y_index"
+      "SELECT topics.text, votes.voter_display_name, topics.status, topics.display_name, topics.created_timestamp, topics.y_index, topics.finished_at"
           + " FROM topics"
           + " LEFT JOIN votes ON topics.session_id = votes.topic_author_session_id AND topics.text = votes.topic_text"
           + " WHERE  topics.session_id = :sessionId"
@@ -22,12 +23,13 @@ public interface TopicsRepository extends CrudRepository<TopicsEntity, TopicsId>
 
   @Modifying
   @Query(value = "UPDATE topics " +
-      "SET status = :command, y_index = 999 " +
+      "SET status = :command, finished_at = :finishedAt " +
       "WHERE text = :text and session_id = :sessionId and display_name = :displayName",
       nativeQuery = true)
   void updateStatusByTextAndSessionIdAndDisplayName(@Param("command") final String command,
       @Param("text") final String text, @Param("sessionId") final String sessionId,
-      @Param("displayName") final String displayName);
+      @Param("displayName") final String displayName,
+      @Param("finishedAt") final Timestamp finishedAt);
 
   @Transactional
   @Modifying

--- a/backend/src/main/java/com/leancoffree/backend/repository/TopicsRepository.java
+++ b/backend/src/main/java/com/leancoffree/backend/repository/TopicsRepository.java
@@ -3,6 +3,7 @@ package com.leancoffree.backend.repository;
 import com.leancoffree.backend.domain.entity.TopicsEntity;
 import com.leancoffree.backend.domain.entity.TopicsEntity.TopicsId;
 import java.util.List;
+import javax.transaction.Transactional;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -11,7 +12,7 @@ import org.springframework.data.repository.query.Param;
 public interface TopicsRepository extends CrudRepository<TopicsEntity, TopicsId> {
 
   @Query(value =
-      "SELECT topics.text, votes.voter_display_name, topics.status, topics.display_name, topics.created_timestamp"
+      "SELECT topics.text, votes.voter_display_name, topics.status, topics.display_name, topics.created_timestamp, topics.y_index"
           + " FROM topics"
           + " LEFT JOIN votes ON topics.session_id = votes.topic_author_session_id AND topics.text = votes.topic_text"
           + " WHERE  topics.session_id = :sessionId"
@@ -27,4 +28,15 @@ public interface TopicsRepository extends CrudRepository<TopicsEntity, TopicsId>
   void updateStatusByTextAndSessionIdAndDisplayName(@Param("command") final String command,
       @Param("text") final String text, @Param("sessionId") final String sessionId,
       @Param("displayName") final String displayName);
+
+  @Transactional
+  @Modifying
+  @Query(value = "UPDATE topics " +
+      "SET y_index = :yIndex " +
+      "WHERE text = :text and session_id = :sessionId",
+      nativeQuery = true)
+  void updateYIndexByTextAndSessionId(@Param("yIndex") final long yIndex,
+      @Param("text") final String text, @Param("sessionId") final String sessionId);
+
+  List<TopicsEntity> findAllBySessionIdOrderByText(final String sessionId);
 }

--- a/backend/src/main/java/com/leancoffree/backend/repository/TopicsRepository.java
+++ b/backend/src/main/java/com/leancoffree/backend/repository/TopicsRepository.java
@@ -22,7 +22,7 @@ public interface TopicsRepository extends CrudRepository<TopicsEntity, TopicsId>
 
   @Modifying
   @Query(value = "UPDATE topics " +
-      "SET status = :command " +
+      "SET status = :command, y_index = 999 " +
       "WHERE text = :text and session_id = :sessionId and display_name = :displayName",
       nativeQuery = true)
   void updateStatusByTextAndSessionIdAndDisplayName(@Param("command") final String command,
@@ -39,4 +39,6 @@ public interface TopicsRepository extends CrudRepository<TopicsEntity, TopicsId>
       @Param("text") final String text, @Param("sessionId") final String sessionId);
 
   List<TopicsEntity> findAllBySessionIdOrderByText(final String sessionId);
+
+  List<TopicsEntity> findAllBySessionIdOrderByVerticalIndex(final String sessionId);
 }

--- a/backend/src/main/java/com/leancoffree/backend/repository/VotesRepository.java
+++ b/backend/src/main/java/com/leancoffree/backend/repository/VotesRepository.java
@@ -1,7 +1,10 @@
 package com.leancoffree.backend.repository;
 
 import com.leancoffree.backend.domain.entity.VotesEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface VotesRepository extends CrudRepository<VotesEntity, Long> {
 
@@ -12,4 +15,12 @@ public interface VotesRepository extends CrudRepository<VotesEntity, Long> {
       final String text, final String voterDisplayName);
 
   void deleteByVoterSessionIdAndText(final String sessionId, final String text);
+
+  @Query(value = "SELECT topic_text, count(*) " +
+      "FROM votes " +
+      "WHERE voter_session_id = :sessionId " +
+      "GROUP BY topic_text " +
+      "ORDER BY count(*) desc, topic_text",
+      nativeQuery = true)
+  List<Object[]> findVotesInOrder(@Param("sessionId") final String sessionId);
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionServiceImpl.java
@@ -126,6 +126,9 @@ public class AddUserToSessionServiceImpl implements AddUserToSessionService {
         moderatorName = usersEntity.getDisplayName();
       }
     }
+    if(moderatorName == null) {
+      moderatorName = "";
+    }
     return Map.entry(displayNames, moderatorName);
   }
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/AddUserToSessionServiceImpl.java
@@ -2,7 +2,7 @@ package com.leancoffree.backend.service;
 
 import static com.leancoffree.backend.enums.SessionStatus.DISCUSSING;
 import static com.leancoffree.backend.enums.SortTopicsBy.CREATION;
-import static com.leancoffree.backend.enums.SortTopicsBy.VOTES;
+import static com.leancoffree.backend.enums.SortTopicsBy.Y_INDEX;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
 
@@ -81,7 +81,7 @@ public class AddUserToSessionServiceImpl implements AddUserToSessionService {
             .put("moderator", displayNamesAndModeratorName.getValue()).toString();
         final SortTopicsBy sortTopicsBy =
             sessionsEntityOptional.get().getSessionStatus().equals(DISCUSSING)
-                ? VOTES
+                ? Y_INDEX
                 : CREATION;
 
         webSocketMessagingTemplate

--- a/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsServiceImpl.java
@@ -1,7 +1,7 @@
 package com.leancoffree.backend.service;
 
 import static com.leancoffree.backend.enums.SortTopicsBy.CREATION;
-import static com.leancoffree.backend.enums.SortTopicsBy.VOTES;
+import static com.leancoffree.backend.enums.SortTopicsBy.Y_INDEX;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
 import static com.leancoffree.backend.enums.TopicStatus.DISCUSSING;
@@ -16,7 +16,6 @@ import com.leancoffree.backend.repository.TopicsRepository;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -76,7 +75,7 @@ public class BroadcastTopicsServiceImpl implements BroadcastTopicsService {
         topicDetailsList.add(entry.getValue());
       }
 
-      if (VOTES.equals(sortTopicsBy)) {
+      if (Y_INDEX.equals(sortTopicsBy)) {
         topicDetailsList.sort((a, b) -> b.getVoters().size() - a.getVoters().size());
       } else if (CREATION.equals(sortTopicsBy)) {
         topicDetailsList.sort(Comparator.comparing(TopicDetails::getCreationDate));

--- a/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsServiceImpl.java
@@ -91,7 +91,7 @@ public class BroadcastTopicsServiceImpl implements BroadcastTopicsService {
             .topicStatus(TopicStatus.valueOf(currentDiscussionItem.getTopicStatus()))
             .displayName(currentDiscussionItem.getAuthorDisplayName())
             .createdTimestamp(currentDiscussionItem.getCreationDate())
-            .yIndex(0)
+            .verticalIndex(999)
             .build();
         topicsRepository.save(topicsEntity);
       }

--- a/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/BroadcastTopicsServiceImpl.java
@@ -67,7 +67,7 @@ public class BroadcastTopicsServiceImpl implements BroadcastTopicsService {
 
         topicsAndVotersMap
             .put(text, new TopicDetails(text, (String) objects[3], (String) objects[2], voters,
-                ((Timestamp) objects[4]).toInstant()));
+                ((Timestamp) objects[4]).toInstant(), (Integer) objects[5]));
       }
 
       final List<TopicDetails> topicDetailsList = new ArrayList<>();
@@ -76,7 +76,7 @@ public class BroadcastTopicsServiceImpl implements BroadcastTopicsService {
       }
 
       if (Y_INDEX.equals(sortTopicsBy)) {
-        topicDetailsList.sort((a, b) -> b.getVoters().size() - a.getVoters().size());
+        topicDetailsList.sort(Comparator.comparing(TopicDetails::getYIndex));
       } else if (CREATION.equals(sortTopicsBy)) {
         topicDetailsList.sort(Comparator.comparing(TopicDetails::getCreationDate));
       }
@@ -91,6 +91,7 @@ public class BroadcastTopicsServiceImpl implements BroadcastTopicsService {
             .topicStatus(TopicStatus.valueOf(currentDiscussionItem.getTopicStatus()))
             .displayName(currentDiscussionItem.getAuthorDisplayName())
             .createdTimestamp(currentDiscussionItem.getCreationDate())
+            .yIndex(0)
             .build();
         topicsRepository.save(topicsEntity);
       }
@@ -142,5 +143,6 @@ public class BroadcastTopicsServiceImpl implements BroadcastTopicsService {
     private String topicStatus;
     private List<String> voters;
     private Instant creationDate;
+    private Integer yIndex;
   }
 }

--- a/backend/src/main/java/com/leancoffree/backend/service/DeleteTopicServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/DeleteTopicServiceImpl.java
@@ -1,7 +1,7 @@
 package com.leancoffree.backend.service;
 
 import static com.leancoffree.backend.enums.SortTopicsBy.CREATION;
-import static com.leancoffree.backend.enums.SortTopicsBy.VOTES;
+import static com.leancoffree.backend.enums.SortTopicsBy.Y_INDEX;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
 
@@ -58,7 +58,7 @@ public class DeleteTopicServiceImpl implements DeleteTopicService {
     final SortTopicsBy sortTopicsBy =
         sessionsEntityOptional.get().getSessionStatus() == SessionStatus.STARTED
             ? CREATION
-            : VOTES;
+            : Y_INDEX;
 
     broadcastTopicsService.broadcastTopics(deleteTopicRequest.getSessionId(), sortTopicsBy, false);
     return new SuccessOrFailureAndErrorBody(SUCCESS, null);

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
@@ -2,7 +2,7 @@ package com.leancoffree.backend.service;
 
 import static com.leancoffree.backend.enums.RefreshTopicsCommand.FINISH;
 import static com.leancoffree.backend.enums.RefreshTopicsCommand.NEXT;
-import static com.leancoffree.backend.enums.SortTopicsBy.VOTES;
+import static com.leancoffree.backend.enums.SortTopicsBy.Y_INDEX;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
 import static com.leancoffree.backend.enums.TopicStatus.DISCUSSED;
@@ -54,14 +54,14 @@ public class RefreshTopicsServiceImpl implements RefreshTopicsService {
         sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(180));
         sessionsRepository.save(sessionsEntity);
 
-        broadcastTopicsService.broadcastTopics(refreshTopicsRequest.getSessionId(), VOTES, false);
+        broadcastTopicsService.broadcastTopics(refreshTopicsRequest.getSessionId(), Y_INDEX, false);
         return new SuccessOrFailureAndErrorBody(SUCCESS, null);
       }
     } else if (FINISH.equals(refreshTopicsRequest.getCommand())) {
       topicsRepository.updateStatusByTextAndSessionIdAndDisplayName(DISCUSSED.toString(),
           refreshTopicsRequest.getCurrentTopicText(), refreshTopicsRequest.getSessionId(),
           refreshTopicsRequest.getCurrentTopicAuthorDisplayName());
-      broadcastTopicsService.broadcastTopics(refreshTopicsRequest.getSessionId(), VOTES, false);
+      broadcastTopicsService.broadcastTopics(refreshTopicsRequest.getSessionId(), Y_INDEX, false);
       return new SuccessOrFailureAndErrorBody(SUCCESS, null);
     }
     return new SuccessOrFailureAndErrorBody(FAILURE, "Command or topic/session invalid");

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
@@ -13,6 +13,7 @@ import com.leancoffree.backend.domain.model.RefreshTopicsRequest;
 import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
 import com.leancoffree.backend.repository.SessionsRepository;
 import com.leancoffree.backend.repository.TopicsRepository;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Optional;
 import javax.transaction.Transactional;
@@ -48,11 +49,11 @@ public class RefreshTopicsServiceImpl implements RefreshTopicsService {
       if (sessionsEntityOptional.isPresent()) {
         topicsRepository.updateStatusByTextAndSessionIdAndDisplayName(DISCUSSED.toString(),
             refreshTopicsRequest.getCurrentTopicText(), refreshTopicsRequest.getSessionId(),
-            refreshTopicsRequest.getCurrentTopicAuthorDisplayName());
+            refreshTopicsRequest.getCurrentTopicAuthorDisplayName(), Timestamp.from(Instant.now()));
 
         topicsRepository.updateStatusByTextAndSessionIdAndDisplayName(DISCUSSING.toString(),
             refreshTopicsRequest.getNextTopicText(), refreshTopicsRequest.getSessionId(),
-            refreshTopicsRequest.getNextTopicAuthorDisplayName());
+            refreshTopicsRequest.getNextTopicAuthorDisplayName(), null);
 
         final SessionsEntity sessionsEntity = sessionsEntityOptional.get();
         sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(defaultTopicTime));
@@ -64,7 +65,7 @@ public class RefreshTopicsServiceImpl implements RefreshTopicsService {
     } else if (FINISH.equals(refreshTopicsRequest.getCommand())) {
       topicsRepository.updateStatusByTextAndSessionIdAndDisplayName(DISCUSSED.toString(),
           refreshTopicsRequest.getCurrentTopicText(), refreshTopicsRequest.getSessionId(),
-          refreshTopicsRequest.getCurrentTopicAuthorDisplayName());
+          refreshTopicsRequest.getCurrentTopicAuthorDisplayName(), Timestamp.from(Instant.now()));
       broadcastTopicsService.broadcastTopics(refreshTopicsRequest.getSessionId(), Y_INDEX, false);
       return new SuccessOrFailureAndErrorBody(SUCCESS, null);
     }

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
@@ -16,10 +16,14 @@ import com.leancoffree.backend.repository.TopicsRepository;
 import java.time.Instant;
 import java.util.Optional;
 import javax.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 public class RefreshTopicsServiceImpl implements RefreshTopicsService {
+
+  @Value("${defaultTopicTime}")
+  private Integer defaultTopicTime;
 
   private final TopicsRepository topicsRepository;
   private final BroadcastTopicsService broadcastTopicsService;
@@ -51,7 +55,7 @@ public class RefreshTopicsServiceImpl implements RefreshTopicsService {
             refreshTopicsRequest.getNextTopicAuthorDisplayName());
 
         final SessionsEntity sessionsEntity = sessionsEntityOptional.get();
-        sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(180));
+        sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(defaultTopicTime));
         sessionsRepository.save(sessionsEntity);
 
         broadcastTopicsService.broadcastTopics(refreshTopicsRequest.getSessionId(), Y_INDEX, false);

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class RefreshTopicsServiceImpl implements RefreshTopicsService {
 
-  @Value("${defaultTopicTime}")
+  @Value("${defaultTopicTime:180}")
   private Integer defaultTopicTime;
 
   private final TopicsRepository topicsRepository;

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshTopicsServiceImpl.java
@@ -51,7 +51,7 @@ public class RefreshTopicsServiceImpl implements RefreshTopicsService {
             refreshTopicsRequest.getNextTopicAuthorDisplayName());
 
         final SessionsEntity sessionsEntity = sessionsEntityOptional.get();
-        sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(5));
+        sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(180));
         sessionsRepository.save(sessionsEntity);
 
         broadcastTopicsService.broadcastTopics(refreshTopicsRequest.getSessionId(), VOTES, false);

--- a/backend/src/main/java/com/leancoffree/backend/service/RefreshUsersServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/RefreshUsersServiceImpl.java
@@ -3,7 +3,7 @@ package com.leancoffree.backend.service;
 import static com.leancoffree.backend.enums.RefreshUsersCommand.ADD;
 import static com.leancoffree.backend.enums.SessionStatus.DISCUSSING;
 import static com.leancoffree.backend.enums.SortTopicsBy.CREATION;
-import static com.leancoffree.backend.enums.SortTopicsBy.VOTES;
+import static com.leancoffree.backend.enums.SortTopicsBy.Y_INDEX;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
 
@@ -88,7 +88,7 @@ public class RefreshUsersServiceImpl implements RefreshUsersService {
           .put("moderator", moderatorName).toString();
       final SortTopicsBy sortTopicsBy =
           sessionsEntityOptional.get().getSessionStatus().equals(DISCUSSING)
-              ? VOTES
+              ? Y_INDEX
               : CREATION;
 
       webSocketMessagingTemplate

--- a/backend/src/main/java/com/leancoffree/backend/service/ReorderTopicsService.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/ReorderTopicsService.java
@@ -1,0 +1,9 @@
+package com.leancoffree.backend.service;
+
+import com.leancoffree.backend.domain.model.ReorderTopicsRequest;
+import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+
+public interface ReorderTopicsService {
+
+  SuccessOrFailureAndErrorBody reorderTopics(final ReorderTopicsRequest reorderTopicsRequest);
+}

--- a/backend/src/main/java/com/leancoffree/backend/service/ReorderTopicsServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/ReorderTopicsServiceImpl.java
@@ -1,0 +1,52 @@
+package com.leancoffree.backend.service;
+
+import static com.leancoffree.backend.enums.SortTopicsBy.Y_INDEX;
+import static com.leancoffree.backend.enums.SuccessOrFailure.*;
+
+import com.leancoffree.backend.domain.entity.TopicsEntity;
+import com.leancoffree.backend.domain.model.ReorderTopicsRequest;
+import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.repository.TopicsRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReorderTopicsServiceImpl implements ReorderTopicsService {
+
+  private final TopicsRepository topicsRepository;
+  private final BroadcastTopicsService broadcastTopicsService;
+
+  public ReorderTopicsServiceImpl(final TopicsRepository topicsRepository,
+      final BroadcastTopicsService broadcastTopicsService) {
+    this.topicsRepository = topicsRepository;
+    this.broadcastTopicsService = broadcastTopicsService;
+  }
+
+  public SuccessOrFailureAndErrorBody reorderTopics(
+      final ReorderTopicsRequest reorderTopicsRequest) {
+
+    final List<TopicsEntity> topics = topicsRepository
+        .findAllBySessionIdOrderByVerticalIndex(reorderTopicsRequest.getSessionId());
+
+    boolean topicFound = false;
+    TopicsEntity topicToReorder = null;
+    for (int i = 0; i < topics.size() && !topicFound; i++) {
+      if (topics.get(i).getText().equals(reorderTopicsRequest.getText())) {
+        topicToReorder = topics.get(i);
+        topics.remove(i);
+        topicFound = true;
+      }
+    }
+
+    if (topicToReorder != null) {
+      topics.add(reorderTopicsRequest.getNewIndex(), topicToReorder);
+      for (int i = 0; i < topics.size(); i++) {
+        topics.get(i).setVerticalIndex(i);
+        topicsRepository.save(topics.get(i));
+      }
+      broadcastTopicsService.broadcastTopics(reorderTopicsRequest.getSessionId(), Y_INDEX, false);
+      return new SuccessOrFailureAndErrorBody(SUCCESS, null);
+    }
+    return new SuccessOrFailureAndErrorBody(FAILURE, "Couldn't find topic to reorder");
+  }
+}

--- a/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
@@ -1,6 +1,6 @@
 package com.leancoffree.backend.service;
 
-import static com.leancoffree.backend.enums.SortTopicsBy.VOTES;
+import static com.leancoffree.backend.enums.SortTopicsBy.Y_INDEX;
 import static com.leancoffree.backend.enums.SuccessOrFailure.FAILURE;
 import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
 
@@ -8,6 +8,7 @@ import com.leancoffree.backend.domain.entity.SessionsEntity;
 import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
 import com.leancoffree.backend.enums.SessionStatus;
 import com.leancoffree.backend.repository.SessionsRepository;
+import com.leancoffree.backend.repository.TopicsRepository;
 import java.time.Instant;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
@@ -16,12 +17,15 @@ import org.springframework.stereotype.Service;
 public class TransitionToDiscussionServiceImpl implements TransitionToDiscussionService {
 
   private final SessionsRepository sessionsRepository;
+  private final TopicsRepository topicsRepository;
   private final BroadcastTopicsService broadcastTopicsService;
 
   public TransitionToDiscussionServiceImpl(final SessionsRepository sessionsRepository,
-      final BroadcastTopicsService broadcastTopicsService) {
+      final BroadcastTopicsService broadcastTopicsService,
+      final TopicsRepository topicsRepository) {
     this.sessionsRepository = sessionsRepository;
     this.broadcastTopicsService = broadcastTopicsService;
+    this.topicsRepository = topicsRepository;
   }
 
   public SuccessOrFailureAndErrorBody transitionToDiscussion(final String sessionId) {
@@ -35,7 +39,10 @@ public class TransitionToDiscussionServiceImpl implements TransitionToDiscussion
     sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(180));
     sessionsRepository.save(sessionsEntity);
 
-    broadcastTopicsService.broadcastTopics(sessionId, VOTES, true);
+    // assign y value to topics by most votes, fallback on creation date?
+
+
+    broadcastTopicsService.broadcastTopics(sessionId, Y_INDEX, true);
 
     return new SuccessOrFailureAndErrorBody(SUCCESS, null);
   }

--- a/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
@@ -32,7 +32,7 @@ public class TransitionToDiscussionServiceImpl implements TransitionToDiscussion
 
     final SessionsEntity sessionsEntity = sessionsEntityOptional.get();
     sessionsEntity.setSessionStatus(SessionStatus.DISCUSSING);
-    sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(5));
+    sessionsEntity.setCurrentTopicEndTime(Instant.now().plusSeconds(180));
     sessionsRepository.save(sessionsEntity);
 
     broadcastTopicsService.broadcastTopics(sessionId, VOTES, true);

--- a/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/TransitionToDiscussionServiceImpl.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class TransitionToDiscussionServiceImpl implements TransitionToDiscussionService {
 
-  @Value("${defaultTopicTime}")
+  @Value("${defaultTopicTime:180}")
   private Integer defaultTopicTime;
 
   private final SessionsRepository sessionsRepository;

--- a/backend/src/main/resources/application-template.yml
+++ b/backend/src/main/resources/application-template.yml
@@ -5,3 +5,5 @@
 #
 #server:
 #  port: 8085
+#
+#defaultTopicTime: 5

--- a/backend/src/main/resources/db/V11_AddYIndexColumnToTopicsTable.sql
+++ b/backend/src/main/resources/db/V11_AddYIndexColumnToTopicsTable.sql
@@ -1,0 +1,2 @@
+alter table topics
+add column y_index int;

--- a/backend/src/main/resources/db/V12_AddFinishedAtColumnToTopicsTable.sql
+++ b/backend/src/main/resources/db/V12_AddFinishedAtColumnToTopicsTable.sql
@@ -1,0 +1,2 @@
+alter table topics
+add column finished_at timestamp;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,16 +6,20 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "add": "^2.0.6",
     "axios": "^0.20.0",
     "bootstrap": "^4.5.2",
     "react": "^16.13.1",
+    "react-beautiful-dnd": "^13.0.0",
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.3",
     "react-stomp": "^5.0.0",
     "reactstrap": "^8.5.1",
-    "sockjs-client": "^1.5.0"
+    "sockjs-client": "^1.5.0",
+    "styled-components": "^5.2.1",
+    "yarn": "^1.22.10"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -109,37 +109,47 @@ class DiscussionPage extends React.Component {
         topics.push({votes: votes, text: text});
       }
 
-      let dragAndDropPrompt = this.props.userInfo.displayName === this.props.moderatorName && this.state.topics.discussionBacklogTopics.length > 1 && this.props.isUsernameModalOpen === false
-      ? <p style={{marginLeft: '2.5vw', marginRight: '2.5vw'}}>Drag and drop topic cards to reorder the discussion queue</p>
-      : null;
-
-      return topics.length === 0
-       ? null
-       : <div style={{gridRow: '1 / span 2', gridColumn: 1, borderRight: 'solid black 1px', minHeight: '100vh', maxHeight: '100vh', overflow: 'hidden'}}>
-         {dragAndDropPrompt}
-          <DragDropContext onDragEnd={this.onDragEnd}>
-            <Droppable droppableId="droppable">
-              {(provided, snapshot) => (
-                <div {...provided.droppableProps} class="discussCards-container" style={{paddingBottom: this.props.userInfo.displayName === this.props.moderatorName ? '7.5vw' : '0'}} ref={provided.innerRef}>
-                  {topics.map((item, index) => (
-                    <Draggable key={index.toString()}  draggableId={'draggable' + index} index={index}>
-                      {(provided) => (
-                        <Container ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
-                          <p class="topicText">{item.text}</p>
-                          <p class="votesText">Votes: {item.votes}</p>
-                        </Container>
-                      )}
-                    </Draggable>
-                  ))}
-                  {provided.placeholder}
-                </div>
-              )}
-            </Droppable>
-          </DragDropContext>
-        </div>;
-    } else {
-      return null;
+      if(this.props.userInfo.displayName === this.props.moderatorName && this.state.topics.discussionBacklogTopics.length > 1 && this.props.isUsernameModalOpen === false) {
+        return topics.length === 0
+        ? null
+        : <div style={{gridRow: '1 / span 2', width: '20vw', gridColumn: 1, borderRight: 'solid black 1px', minHeight: '100vh', maxHeight: '100vh', overflow: 'hidden'}}>
+            <p style={{marginLeft: '2.5vw', marginRight: '2.5vw'}}>Drag and drop topic cards to reorder the discussion queue</p>
+            <DragDropContext onDragEnd={this.onDragEnd}>
+              <Droppable droppableId="droppable">
+                {(provided, snapshot) => (
+                  <div {...provided.droppableProps} class="discussCards-container" style={{paddingBottom: '7.5vw'}} ref={provided.innerRef}>
+                    {topics.map((item, index) => (
+                      <Draggable key={index.toString()}  draggableId={'draggable' + index} index={index}>
+                        {(provided) => (
+                          <Container ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
+                            <p class="topicText">{item.text}</p>
+                            <p class="votesText">Votes: {item.votes}</p>
+                          </Container>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                  </div>
+                )}
+              </Droppable>
+            </DragDropContext>
+          </div>;
+      } else {
+        return topics.length === 0
+        ? null
+        : (
+          <div class="discussCards-container" style={{gridRow: '1 / span 2', gridColumn: 1, borderRight: 'solid black 1px', minHeight: '100vh', maxHeight: '100vh', overflow: 'scroll'}}>
+            {topics.map((item, index) => (
+              <div key={index.toString()} class="cardItem discussionCardItem" style={{gridRow: index + 1, marginLeft: '2.5vw', marginRight: '2.5vw'}}>
+                <p class="topicText">{item.text}</p>
+                <p class="votesText">Votes: {item.votes}</p>
+              </div>
+            ))}
+          </div>
+        );
+      }
     }
+    return null;
   }
 
   getDiscussedCards(isFinished) {

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -109,27 +109,34 @@ class DiscussionPage extends React.Component {
         topics.push({votes: votes, text: text});
       }
 
+      let dragAndDropPrompt = this.props.userInfo.displayName === this.props.moderatorName && this.state.topics.discussionBacklogTopics.length > 1 && this.props.isUsernameModalOpen === false
+      ? <p style={{marginLeft: '2.5vw', marginRight: '2.5vw'}}>Drag and drop topic cards to reorder the discussion queue</p>
+      : null;
+
       return topics.length === 0
        ? null
-       : <DragDropContext onDragEnd={this.onDragEnd}>
-          <Droppable droppableId="droppable">
-            {(provided, snapshot) => (
-              <div {...provided.droppableProps} class="discussCards-container" ref={provided.innerRef}>
-                {topics.map((item, index) => (
-                  <Draggable key={index.toString()}  draggableId={'draggable' + index} index={index}>
-                    {(provided) => (
-                      <Container ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
-                        <p class="topicText">{item.text}</p>
-                        <p class="votesText">Votes: {item.votes}</p>
-                      </Container>
-                    )}
-                  </Draggable>
-                ))}
-                {provided.placeholder}
-              </div>
-            )}
-          </Droppable>
-        </DragDropContext>; 
+       : <div style={{gridRow: '1 / span 2', gridColumn: 1, borderRight: 'solid black 1px', minHeight: '100vh', maxHeight: '100vh', overflow: 'hidden'}}>
+         {dragAndDropPrompt}
+          <DragDropContext onDragEnd={this.onDragEnd}>
+            <Droppable droppableId="droppable">
+              {(provided, snapshot) => (
+                <div {...provided.droppableProps} class="discussCards-container" style={{paddingBottom: this.props.userInfo.displayName === this.props.moderatorName ? '7.5vw' : '0'}} ref={provided.innerRef}>
+                  {topics.map((item, index) => (
+                    <Draggable key={index.toString()}  draggableId={'draggable' + index} index={index}>
+                      {(provided) => (
+                        <Container ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
+                          <p class="topicText">{item.text}</p>
+                          <p class="votesText">Votes: {item.votes}</p>
+                        </Container>
+                      )}
+                    </Draggable>
+                  ))}
+                  {provided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </DragDropContext>
+        </div>;
     } else {
       return null;
     }
@@ -189,10 +196,7 @@ class DiscussionPage extends React.Component {
       ? "Session completed!"
       : this.state.topics.currentDiscussionItem.text;
 
-    let allTopicCards = this.getAllTopicCards();
-    let allTopicCardsContainer = allTopicCards === null
-      ? null
-      : allTopicCards;
+    let allTopicCardsContainer = this.getAllTopicCards();
 
     let currentDiscussionItemContainer = allTopicCardsContainer === null 
       ? <div class="currentDiscussionItem column1">

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -154,16 +154,17 @@ class DiscussionPage extends React.Component {
 
   getDiscussedCards(isFinished) {
     if(this.state.topics.discussedTopics !== undefined && this.state.topics.discussedTopics.length !== 0) {
+      let topics = this.state.topics.discussedTopics;
       let allDiscussedTopicsElements = [];
-      for(let i = 0; i <= this.state.topics.discussedTopics.length; i++) {
-        if(i === (this.state.topics.discussedTopics.length)) {
+      for(let i = 0; i <= topics.length; i++) {
+        if(i === (topics.length)) {
           allDiscussedTopicsElements.push(
             <div key={i.toString()} class="finalSpacer row1" style={{gridColumn: i + 1}}/>
           )
         } else {
           allDiscussedTopicsElements.push(
             <div key={i.toString()} class="cardItem row1" style={{gridColumn: i + 1}}>
-              <p class="topicText">{this.state.topics.discussedTopics[i].text}</p>
+              <p class="topicText">{topics[i].text}</p>
             </div>
           )
         }

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -87,6 +87,16 @@ class DiscussionPage extends React.Component {
     let allTopics = this.state.topics;
     allTopics.discussionBacklogTopics = topics;
     this.setState({topics: allTopics});
+    
+    Axios.post(process.env.REACT_APP_BACKEND_BASEURL + '/reorder', {sessionId: this.props.sessionId, text: topic.text, newIndex: result.destination.index})
+      .then((response) => {
+        if(response.data.status !== "SUCCESS") {
+          alert(response.data.error);
+        }
+      })
+      .catch((error) => 
+        alert("Unable to reorder topic\n" + error)
+      );
   }
 
   getAllTopicCards() {

--- a/frontend/src/session/Session.js
+++ b/frontend/src/session/Session.js
@@ -331,7 +331,7 @@ class Session extends React.Component {
         <div>
           {usernameModal}
           {shareableLinkModal}
-          <DiscussionPage sessionId={this.state.sessionId} getAllHere={this.getAllHere} topics={this.state.topics} currentEndTime={this.state.currentTopicEndTime} userInfo={{displayName: this.state.userDisplayName}} />
+          <DiscussionPage isUsernameModalOpen={usernameModal !== null} sessionId={this.state.sessionId} getAllHere={this.getAllHere} topics={this.state.topics} currentEndTime={this.state.currentTopicEndTime} userInfo={{displayName: this.state.userDisplayName}} moderatorName={this.state.usersInAttendance.moderator} />
         </div>
       )
     }

--- a/frontend/src/session/session.css
+++ b/frontend/src/session/session.css
@@ -12,7 +12,6 @@
 }
 
 .discussCards-container {
-  display: grid;
   width: 20vw;
   min-height: 100vh;
   max-height: 100vh;

--- a/frontend/src/session/session.css
+++ b/frontend/src/session/session.css
@@ -13,12 +13,8 @@
 
 .discussCards-container {
   width: 20vw;
-  min-height: 100vh;
   max-height: 100vh;
-  border-right: solid black 1px;
   overflow: scroll;
-  grid-row: 1 / span 2;
-  grid-column: 1;
 }
 
 .cardsSection {

--- a/frontend/src/session/session.css
+++ b/frontend/src/session/session.css
@@ -11,7 +11,7 @@
   max-width: 100vw;
 }
 
-.discussCards-grid-container {
+.discussCards-container {
   display: grid;
   width: 20vw;
   min-height: 100vh;
@@ -112,12 +112,6 @@
 .column3 {
   grid-column: 3;
   grid-row: 1 / span 2;
-}
-
-.discussionCardItem {
-  grid-column: 1;
-  margin-left: 2.5vw;
-  margin-right: 2.5vw;
 }
 
 .currentTopicHeader{

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -56,6 +56,15 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.1.tgz#0d70be32bdaa03d7c51c8597dda76e0df1f15468"
+  integrity sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==
+  dependencies:
+    "@babel/types" "^7.12.1"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.4.0", "@babel/generator@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.0.tgz#0f67adea4ec39dad6e63345f70eec33014d78c89"
@@ -65,6 +74,13 @@
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
+
+"@babel/helper-annotate-as-pure@^7.0.0":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz#5bf0d495a3f757ac3bda48b5bf3b3ba309c72ba3"
+  integrity sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==
+  dependencies:
+    "@babel/types" "^7.10.4"
 
 "@babel/helper-annotate-as-pure@^7.8.3":
   version "7.8.3"
@@ -220,6 +236,13 @@
   integrity sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-module-imports@^7.0.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz#1644c01591a15a2f084dd6d092d9430eb1d1216c"
+  integrity sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==
+  dependencies:
+    "@babel/types" "^7.12.1"
 
 "@babel/helper-module-imports@^7.8.3":
   version "7.8.3"
@@ -381,6 +404,11 @@
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
+
+"@babel/parser@^7.12.1":
+  version "7.12.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.3.tgz#a305415ebe7a6c7023b40b5122a0662d928334cd"
+  integrity sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==
 
 "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.8.3"
@@ -1011,6 +1039,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
+  integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1059,6 +1094,21 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/traverse@^7.4.5":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.1.tgz#941395e0c5cc86d5d3e75caa095d3924526f0c1e"
+  integrity sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.1"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.12.1"
+    "@babel/types" "^7.12.1"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
 "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.8.7", "@babel/types@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
@@ -1072,6 +1122,15 @@
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.5.tgz#d9de577d01252d77c6800cee039ee64faf75662d"
   integrity sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.1.tgz#e109d9ab99a8de735be287ee3d6a9947a190c4ae"
+  integrity sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
@@ -1094,6 +1153,28 @@
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
+
+"@emotion/is-prop-valid@^0.8.8":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/stylis@^0.8.4":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
+  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
+
+"@emotion/unitless@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@hapi/address@2.x.x":
   version "2.1.4"
@@ -1903,6 +1984,11 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
+add@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
+  integrity sha1-JI8Kn25aUo7yKV2+7DBTITCuIjU=
+
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
@@ -2355,6 +2441,21 @@ babel-plugin-named-asset-import@^0.3.6:
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.6.tgz#c9750a1b38d85112c9e166bf3ef7c5dbc605f4be"
   integrity sha512-1aGDUfL1qOOIoqk9QKGIo2lANk+C7ko/fqH0uIyC71x3PEGz0uVP8ISgfEsFuG+FKmjHTvFK/nNM8dowpmUxLA==
 
+"babel-plugin-styled-components@>= 1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.11.1.tgz#5296a9e557d736c3186be079fff27c6665d63d76"
+  integrity sha512-YwrInHyKUk1PU3avIRdiLyCpM++18Rs1NgyMXEAQC33rIXs/vro0A+stf4sT0Gf22Got+xRWB8Cm0tw+qkRzBA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
+
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
@@ -2796,6 +2897,11 @@ camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-api@^3.0.0:
   version "3.0.0"
@@ -3348,6 +3454,18 @@ css-blank-pseudo@^0.1.4:
   dependencies:
     postcss "^7.0.5"
 
+css-box-model@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
+  dependencies:
+    tiny-invariant "^1.0.6"
+
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -3418,6 +3536,15 @@ css-select@^2.0.0:
     css-what "^3.2.1"
     domutils "^1.7.0"
     nth-check "^1.0.2"
+
+css-to-react-native@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
+  integrity sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -5097,7 +5224,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -6704,6 +6831,11 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
+memoize-one@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
 memory-fs@^0.4.1:
   version "0.4.1"
@@ -8629,6 +8761,11 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
+raf-schd@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
+  integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
+
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -8677,6 +8814,19 @@ react-app-polyfill@^1.0.6:
     raf "^3.4.1"
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
+
+react-beautiful-dnd@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.0.0.tgz#f70cc8ff82b84bc718f8af157c9f95757a6c3b40"
+  integrity sha512-87It8sN0ineoC3nBW0SbQuTFXM6bUqM62uJGY4BtTf0yzPl8/3+bHMWkgIe0Z6m8e+gJgjWxefGRVfpE3VcdEg==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.1.1"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
 
 react-copy-to-clipboard@^5.0.2:
   version "5.0.2"
@@ -8731,7 +8881,7 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
   integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
 
-react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -8753,6 +8903,17 @@ react-popper@^1.3.6:
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
     warning "^4.0.2"
+
+react-redux@^7.1.1:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.2.tgz#03862e803a30b6b9ef8582dadcc810947f74b736"
+  integrity sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.13.1"
 
 react-router-dom@^5.2.0:
   version "5.2.0"
@@ -8976,6 +9137,14 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
@@ -9536,6 +9705,11 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -10042,6 +10216,22 @@ style-loader@0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
+styled-components@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.2.1.tgz#6ed7fad2dc233825f64c719ffbdedd84ad79101a"
+  integrity sha512-sBdgLWrCFTKtmZm/9x7jkIabjFNVzCUeKfoQsM6R3saImkUnjx0QYdLwJHBjY9ifEcmjDamJDVfknWm1yxZPxQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^0.8.8"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
+    supports-color "^5.5.0"
+
 stylehacks@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5"
@@ -10056,7 +10246,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -10100,6 +10290,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.4"
@@ -10219,7 +10414,7 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-invariant@^1.0.2:
+tiny-invariant@^1.0.2, tiny-invariant@^1.0.6:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
@@ -10520,6 +10715,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-memo-one@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"
+  integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==
 
 use@^3.1.0:
   version "3.1.1"
@@ -11150,3 +11350,8 @@ yargs@^13.3.0, yargs@^13.3.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yarn@^1.22.10:
+  version "1.22.10"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
+  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==


### PR DESCRIPTION
* implement a y-index to sort topics on, initially assigned by backend when transition to discussion (sorted on votes then alphabetical), now no longe sorting on VOTES but on Y_INDEX
* used react-beautiful-dnd to implement drag and drop in frontend, moderator can drag and drop to reorder topic cards, which will trigger call to back end to perform the reordering and broadcasting
* add a finished time column to topics table, set this value when we finish discussing the topic. Then sort the discussed topics section by that value to maintain the y-index ordering in the discussed section