### PR TITLE
Add next topic and end session buttons

### DIFF
--- a/backend/src/main/java/com/leancoffree/backend/controller/EndSessionController.java
+++ b/backend/src/main/java/com/leancoffree/backend/controller/EndSessionController.java
@@ -1,0 +1,27 @@
+package com.leancoffree.backend.controller;
+
+import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.service.EndSessionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class EndSessionController {
+
+  private final EndSessionService endSessionService;
+
+  public EndSessionController(final EndSessionService endSessionService) {
+    this.endSessionService = endSessionService;
+  }
+
+  @CrossOrigin
+  @PostMapping("/end-session/{sessionId}")
+  public ResponseEntity<SuccessOrFailureAndErrorBody> endSessionEndpoint(
+      @PathVariable("sessionId") final String sessionId) {
+    return ResponseEntity.ok(endSessionService.endSession(sessionId));
+  }
+
+}

--- a/backend/src/main/java/com/leancoffree/backend/repository/TopicsRepository.java
+++ b/backend/src/main/java/com/leancoffree/backend/repository/TopicsRepository.java
@@ -43,4 +43,6 @@ public interface TopicsRepository extends CrudRepository<TopicsEntity, TopicsId>
   List<TopicsEntity> findAllBySessionIdOrderByText(final String sessionId);
 
   List<TopicsEntity> findAllBySessionIdOrderByVerticalIndex(final String sessionId);
+
+  void deleteBySessionId(final String sessionId);
 }

--- a/backend/src/main/java/com/leancoffree/backend/repository/UsersRepository.java
+++ b/backend/src/main/java/com/leancoffree/backend/repository/UsersRepository.java
@@ -12,4 +12,5 @@ public interface UsersRepository extends CrudRepository<UsersEntity, UsersId> {
   Optional<UsersEntity> findBySessionIdAndIsModeratorTrue(final String sessionId);
   Optional<UsersEntity> findByWebsocketUserId(final String websocketUserId);
   long countBySessionId(final String sessionId);
+  void deleteBySessionId(final String sessionId);
 }

--- a/backend/src/main/java/com/leancoffree/backend/repository/VotesRepository.java
+++ b/backend/src/main/java/com/leancoffree/backend/repository/VotesRepository.java
@@ -16,6 +16,8 @@ public interface VotesRepository extends CrudRepository<VotesEntity, Long> {
 
   void deleteByVoterSessionIdAndText(final String sessionId, final String text);
 
+  void deleteByVoterSessionId(final String sessionId);
+
   @Query(value = "SELECT topic_text, count(*) " +
       "FROM votes " +
       "WHERE voter_session_id = :sessionId " +

--- a/backend/src/main/java/com/leancoffree/backend/service/EndSessionService.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/EndSessionService.java
@@ -1,0 +1,8 @@
+package com.leancoffree.backend.service;
+
+import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+
+public interface EndSessionService {
+
+  SuccessOrFailureAndErrorBody endSession(final String sessionId);
+}

--- a/backend/src/main/java/com/leancoffree/backend/service/EndSessionServiceImpl.java
+++ b/backend/src/main/java/com/leancoffree/backend/service/EndSessionServiceImpl.java
@@ -1,0 +1,50 @@
+package com.leancoffree.backend.service;
+
+import static com.leancoffree.backend.enums.SuccessOrFailure.SUCCESS;
+
+import com.leancoffree.backend.domain.model.SuccessOrFailureAndErrorBody;
+import com.leancoffree.backend.repository.SessionsRepository;
+import com.leancoffree.backend.repository.TopicsRepository;
+import com.leancoffree.backend.repository.UsersRepository;
+import com.leancoffree.backend.repository.VotesRepository;
+import javax.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EndSessionServiceImpl implements EndSessionService {
+
+  @Value("${frontendBaseUrl:https://leanCoffree.com}")
+  private String frontendBaseUrl;
+
+  private static final String websocketDestination = "/topic/discussion-topics/session/";
+
+  private final SessionsRepository sessionsRepository;
+  private final TopicsRepository topicsRepository;
+  private final VotesRepository votesRepository;
+  private final UsersRepository usersRepository;
+  private final SimpMessagingTemplate webSocketMessagingTemplate;
+
+  public EndSessionServiceImpl(final SessionsRepository sessionsRepository,
+      final TopicsRepository topicsRepository,
+      final VotesRepository votesRepository,
+      final UsersRepository usersRepository,
+      final SimpMessagingTemplate webSocketMessagingTemplate) {
+    this.sessionsRepository = sessionsRepository;
+    this.topicsRepository = topicsRepository;
+    this.votesRepository = votesRepository;
+    this.usersRepository = usersRepository;
+    this.webSocketMessagingTemplate = webSocketMessagingTemplate;
+  }
+
+  @Transactional
+  public SuccessOrFailureAndErrorBody endSession(final String sessionId) {
+    votesRepository.deleteByVoterSessionId(sessionId);
+    topicsRepository.deleteBySessionId(sessionId);
+    usersRepository.deleteBySessionId(sessionId);
+    sessionsRepository.deleteById(sessionId);
+    webSocketMessagingTemplate.convertAndSend(websocketDestination + sessionId, "");
+    return new SuccessOrFailureAndErrorBody(SUCCESS, null);
+  }
+}

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -292,17 +292,19 @@ class DiscussionPage extends React.Component {
   }
 
   endSession() {
-    Axios.post(process.env.REACT_APP_BACKEND_BASEURL + '/end-session/' + this.props.sessionId, {})
-      .then((response) => {
-        if(response.data.status !== "SUCCESS") {
-          alert(response.data.error);
-        } else {
-          return window.location = process.env.REACT_APP_FRONTEND_BASEURL;
-        }
-      })
-      .catch((error) => 
-        alert("Unable to end session\n" + error)
-      );
+    if(window.confirm("Confirm you'd like to end session. All session data will be immediately deleted")) {
+      Axios.post(process.env.REACT_APP_BACKEND_BASEURL + '/end-session/' + this.props.sessionId, {})
+        .then((response) => {
+          if(response.data.status !== "SUCCESS") {
+            alert(response.data.error);
+          } else {
+            return window.location = process.env.REACT_APP_FRONTEND_BASEURL;
+          }
+        })
+        .catch((error) => 
+          alert("Unable to end session\n" + error)
+        );
+    }
   }
 
   getButtons() {

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -31,6 +31,7 @@ class DiscussionPage extends React.Component {
     this.onDragEnd = this.onDragEnd.bind(this);
     this.loadNextTopic = this.loadNextTopic.bind(this);
     this.addTime = this.addTime.bind(this);
+    this.endSession = this.endSession.bind(this);
   }
 
   componentDidMount() {
@@ -290,6 +291,20 @@ class DiscussionPage extends React.Component {
       );
   }
 
+  endSession() {
+    Axios.post(process.env.REACT_APP_BACKEND_BASEURL + '/end-session/' + this.props.sessionId, {})
+      .then((response) => {
+        if(response.data.status !== "SUCCESS") {
+          alert(response.data.error);
+        } else {
+          return window.location = process.env.REACT_APP_FRONTEND_BASEURL;
+        }
+      })
+      .catch((error) => 
+        alert("Unable to end session\n" + error)
+      );
+  }
+
   getButtons() {
     if(this.props.userInfo.displayName !== this.props.moderatorName || this.props.isUsernameModalOpen !== false) {
       return null;
@@ -303,7 +318,7 @@ class DiscussionPage extends React.Component {
       <div style={{gridColumn: 3, gridRow: 2, position: 'relative'}}>
         <div style={{textAlign: 'center', position: 'absolute', bottom: 0, left: 0, right: 0}}>
           {finishTopicButton}
-          <button style={{marginTop: '1vh', marginBottom: '1vh'}}>End Session</button>
+          <button style={{marginTop: '1vh', marginBottom: '1vh'}} onClick={this.endSession}>End Session</button>
         </div>
       </div>
     );

--- a/frontend/src/session/DiscussionPage.js
+++ b/frontend/src/session/DiscussionPage.js
@@ -290,6 +290,25 @@ class DiscussionPage extends React.Component {
       );
   }
 
+  getButtons() {
+    if(this.props.userInfo.displayName !== this.props.moderatorName || this.props.isUsernameModalOpen !== false) {
+      return null;
+    }
+
+    let finishTopicButton = this.state.topics.currentDiscussionItem !== undefined && this.state.topics.currentDiscussionItem.text !== undefined
+      ? <button onClick={() => {if(window.confirm("Confirm you'd like to finish the current topic below\n" + this.state.topics.currentDiscussionItem.text)) this.loadNextTopic()}}>Finish Topic</button>
+      : null;
+
+    return (
+      <div style={{gridColumn: 3, gridRow: 2, position: 'relative'}}>
+        <div style={{textAlign: 'center', position: 'absolute', bottom: 0, left: 0, right: 0}}>
+          {finishTopicButton}
+          <button style={{marginTop: '1vh', marginBottom: '1vh'}}>End Session</button>
+        </div>
+      </div>
+    );
+  }
+
   render() {  
     let countdown;
     if(this.state.currentTopicSecondsRemaining !== -1) {
@@ -375,6 +394,8 @@ class DiscussionPage extends React.Component {
           </ModalBody>
         </Modal>
       );
+
+    let sessionControlButtons = this.getButtons();
       
     return (
       <div class="session-grid-container">
@@ -387,6 +408,7 @@ class DiscussionPage extends React.Component {
           <div>All here:</div>
           <div>{this.props.getAllHere()}</div>
         </div>
+        {sessionControlButtons}
       </div>
     )
   }

--- a/frontend/src/session/Session.js
+++ b/frontend/src/session/Session.js
@@ -85,6 +85,9 @@ class Session extends React.Component {
       (frame) => {
         stompClient.subscribe('/topic/discussion-topics/session/' + this.state.sessionId, 
           (payload) => {
+            if(payload.body === "") {
+              return window.location = process.env.REACT_APP_FRONTEND_BASEURL;
+            }
             if(JSON.parse(payload.body).currentDiscussionItem.text === undefined) {
               this.setState({topics: JSON.parse(payload.body)});
             } else {


### PR DESCRIPTION
* add session control buttons for moderator in the discussion page, can click next topic to go to next queued topic at any point, or end session at any point
* ending session wipes all session data and redirects users to home screen